### PR TITLE
fix: linting warnings and UI improvements

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -135,7 +135,6 @@ addopts = "-v --tb=short"
 python_files = ["test_*.py"]
 python_functions = ["test_*"]
 # Don't collect test_ functions from imported source modules
-collect_ignore_glob = ["src/*"]
 norecursedirs = ["src", "dataset", "logs", ".git", "__pycache__"]
 
 [tool.coverage.run]

--- a/src/cooperbench/agents/mini_swe_agent/__init__.py
+++ b/src/cooperbench/agents/mini_swe_agent/__init__.py
@@ -40,8 +40,6 @@ global_config_dir = Path(os.getenv("MSWEA_GLOBAL_CONFIG_DIR") or user_config_dir
 global_config_dir.mkdir(parents=True, exist_ok=True)
 global_config_file = Path(global_config_dir) / ".env"
 
-if not os.getenv("MSWEA_SILENT_STARTUP"):
-    logger.info(f"This is mini-swe-agent version {__version__}. Loading global config from '{global_config_file}'")
 dotenv.load_dotenv(dotenv_path=global_config_file)
 
 

--- a/src/cooperbench/agents/swe_agent/adapter.py
+++ b/src/cooperbench/agents/swe_agent/adapter.py
@@ -6,6 +6,11 @@ AgentRunner interface used by CooperBench.
 SWE-agent 1.0+ supports Modal execution through SWE-ReX.
 """
 
+import os
+
+os.environ.setdefault("SWE_AGENT_LOG_STREAM_LEVEL", "ERROR")
+os.environ.setdefault("SWE_REX_LOG_STREAM_LEVEL", "ERROR")
+
 import asyncio
 import tempfile
 from pathlib import Path
@@ -119,6 +124,14 @@ class SweAgentRunner:
             if "registry_variables" not in agent_yaml_config["tools"]:
                 agent_yaml_config["tools"]["registry_variables"] = {}
             agent_yaml_config["tools"]["registry_variables"]["ROOT"] = working_dir
+
+        # Gemini doesn't support cache_control with function calling, so remove it
+        if "gemini" in model_name.lower():
+            if "history_processors" in agent_yaml_config:
+                agent_yaml_config["history_processors"] = [
+                    hp for hp in agent_yaml_config["history_processors"]
+                    if hp.get("type") != "cache_control"
+                ]
 
         # Configure the model (SWE-agent uses litellm internally)
         model_config = GenericAPIModelConfig(

--- a/src/cooperbench/agents/swe_agent/tooling/tools.py
+++ b/src/cooperbench/agents/swe_agent/tooling/tools.py
@@ -135,7 +135,7 @@ class ToolConfig(BaseModel):
     Unlike `install_commands`, these commands are part of the environment state.
     """
 
-    execution_timeout: int = 30
+    execution_timeout: int = 120
     """Timeout for executing commands in the environment"""
 
     install_timeout: int = 300

--- a/src/cooperbench/eval/backends/modal.py
+++ b/src/cooperbench/eval/backends/modal.py
@@ -1,5 +1,7 @@
 """Modal backend for evaluation."""
 
+from typing import Any
+
 import modal
 
 from cooperbench.eval.backends.base import ExecResult, Sandbox
@@ -8,7 +10,7 @@ from cooperbench.eval.backends.base import ExecResult, Sandbox
 class ModalExecResult:
     """Wrapper for Modal exec result."""
 
-    def __init__(self, result):
+    def __init__(self, result: Any) -> None:
         self._result = result
         self._stdout: str | None = None
         self._stderr: str | None = None

--- a/src/cooperbench/eval/evaluate.py
+++ b/src/cooperbench/eval/evaluate.py
@@ -69,18 +69,18 @@ def evaluate(
         if result:
             if result.get("skipped"):
                 skipped = 1
-                console.print("  [dim]skipped (already evaluated)[/dim]")
+                console.print("[dim]→ skip[/dim] (already evaluated)")
             elif result.get("error"):
                 errors = 1
-                console.print(f"  [red]error:[/red] {result['error']}")
+                console.print(f"[red]✗ error[/red]: {result['error']}")
             elif result.get("both_passed"):
                 passed = 1
-                console.print("  [green]passed[/green] both features")
+                console.print("[green]✓ pass[/green] both features")
             else:
                 failed = 1
                 f1 = "[green]✓[/green]" if result.get("feature1", {}).get("passed") else "[red]✗[/red]"
                 f2 = "[green]✓[/green]" if result.get("feature2", {}).get("passed") else "[red]✗[/red]"
-                console.print(f"  [yellow]partial[/yellow] f1:{f1} f2:{f2}")
+                console.print(f"[yellow]✗ partial[/yellow] f1:{f1} f2:{f2}")
     else:
         # Multiple runs - show progress
         passed, failed, errors, skipped, results = _run_with_progress(runs, eval_run, concurrency)
@@ -214,20 +214,18 @@ def _run_with_progress(runs: list, eval_run, concurrency: int) -> tuple:
 
                     results.append({"run": f"{task_name}/{feat_str}", "status": status})
 
-                    status_style = {
-                        "pass": "green",
-                        "fail": "red",
-                        "skip": "dim",
-                        "error": "yellow",
+                    status_display = {
+                        "pass": "[green]✓ pass[/green]",
+                        "fail": "[red]✗ fail[/red]",
+                        "skip": "[dim]→ skip[/dim]",
+                        "error": "[yellow]✗ error[/yellow]",
                     }[status]
-                    progress.console.print(
-                        f"  [{status_style}]{status}[/{status_style}] {task_name} [dim][{feat_str}][/dim]"
-                    )
+                    progress.console.print(f"{status_display} {task_name} [dim][{feat_str}][/dim]")
 
                 except Exception as e:
                     errors += 1
                     results.append({"run": f"{task_name}/{feat_str}", "status": "error", "error": str(e)})
-                    progress.console.print(f"  [yellow]error[/yellow] {task_name} [dim]{e}[/dim]")
+                    progress.console.print(f"[yellow]✗ error[/yellow] {task_name} [dim]{e}[/dim]")
 
                 progress.update(eval_progress, advance=1)
 

--- a/src/cooperbench/runner/core.py
+++ b/src/cooperbench/runner/core.py
@@ -124,7 +124,7 @@ def run(
         if result:
             if result.get("skipped"):
                 skipped = 1
-                console.print("  [dim]skipped (already completed)[/dim]")
+                console.print("[dim]→ skip[/dim] (already completed)")
             else:
                 completed = 1
                 total_cost = result.get("total_cost", 0)
@@ -280,15 +280,17 @@ def _run_with_progress(tasks: list, execute_task, concurrency: int) -> tuple:
                     total_cost += cost
                     results_list.append({"task": f"{task_name}/{feat_str}", "status": status, "cost": cost})
 
-                    status_color = {"done": "green", "skip": "dim", "failed": "red"}[status]
-                    progress.console.print(
-                        f"  [{status_color}]{status}[/{status_color}] {task_name} [dim][{feat_str}][/dim]"
-                    )
+                    status_display = {
+                        "done": "[green]✓ done[/green]",
+                        "skip": "[dim]→ done[/dim]",
+                        "failed": "[red]✗ failed[/red]",
+                    }[status]
+                    progress.console.print(f"{status_display} {task_name} [dim][{feat_str}][/dim]")
 
                 except Exception as e:
                     failed += 1
                     results_list.append({"task": f"{task_name}/{feat_str}", "status": "error", "error": str(e)})
-                    progress.console.print(f"  [red]error[/red] {task_name} [dim]{e}[/dim]")
+                    progress.console.print(f"[red]✗ error[/red] {task_name} [dim]{e}[/dim]")
 
                 progress.update(task_progress, advance=1)
 


### PR DESCRIPTION
## Summary

- Remove invalid pytest config option `collect_ignore_glob` (fixes pytest warning)
- Add type annotations to `modal.py` to silence mypy notes
- Improve console output formatting with status icons (✓, ✗, →)
- Suppress noisy SWE-agent/SWE-ReX startup logs
- Remove mini-swe-agent startup banner
- Increase execution timeout from 30s to 120s
- Fix Gemini compatibility by removing cache_control history processor

## Description

Cleans up linting warnings and improves the console output UX with consistent status icons across runner and evaluator.

## Changes

- `pyproject.toml`: Remove invalid `collect_ignore_glob` option
- `src/cooperbench/eval/backends/modal.py`: Add type annotations
- `src/cooperbench/eval/evaluate.py`: Consistent status icons in output
- `src/cooperbench/runner/core.py`: Consistent status icons in output
- `src/cooperbench/agents/swe_agent/adapter.py`: Suppress logs, fix Gemini compatibility
- `src/cooperbench/agents/swe_agent/tooling/tools.py`: Increase timeout 30s → 120s
- `src/cooperbench/agents/mini_swe_agent/__init__.py`: Remove startup banner

## Checklist

- [x] Code follows project style
- [x] Tests pass locally
- [ ] Documentation updated (if needed)