### PR TITLE
Remove unused .gitmodules file

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,0 @@
-[submodule "src/cooperbench/execution/openhands_colab"]
-	path = src/cooperbench/execution/openhands_colab
-	url = https://github.com/akhatua2/openhands_colab
-	branch = openhands_colab


### PR DESCRIPTION
The openhands_colab submodule is no longer referenced or used in the codebase.

## Changes

- Deleted `.gitmodules` file (the `src/cooperbench/execution/openhands_colab` submodule path doesn't exist)

## Checklist

- [x] Code follows project style
- [x] Tests pass locally
- [x] Documentation updated (if needed)