### PR TITLE
Re-run tasks with Error status instead of skipping

### DIFF
--- a/src/cooperbench/runner/coop.py
+++ b/src/cooperbench/runner/coop.py
@@ -39,7 +39,11 @@ def execute_coop(
 
     if result_file.exists() and not force:
         with open(result_file) as f:
-            return {"skipped": True, **json.load(f)}
+            prev_result = json.load(f)
+        # Re-run if any agent had an error
+        agents_had_error = any(a.get("status") == "Error" for a in prev_result.get("agents", {}).values())
+        if not agents_had_error:
+            return {"skipped": True, **prev_result}
 
     namespaced_redis = f"{redis_url}#run:{run_id}"
 

--- a/src/cooperbench/runner/solo.py
+++ b/src/cooperbench/runner/solo.py
@@ -29,7 +29,10 @@ def execute_solo(
 
     if result_file.exists() and not force:
         with open(result_file) as f:
-            return {"skipped": True, **json.load(f)}
+            prev_result = json.load(f)
+        # Re-run if previous result was an error
+        if prev_result.get("agent", {}).get("status") != "Error":
+            return {"skipped": True, **prev_result}
 
     try:
         result = _spawn_solo_agent(


### PR DESCRIPTION
## Description

Tasks that previously failed with Error status are now automatically re-run instead of being skipped.

## Changes

- `solo.py`: Skip only if previous result status is not "Error"
- `coop.py`: Skip only if no agent had "Error" status

## Checklist

- [x] Code follows project style
- [ ] Tests pass locally
- [ ] Documentation updated (if needed)