### PR TITLE
Update lite set

### DIFF
--- a/dataset/README.md
+++ b/dataset/README.md
@@ -19,8 +19,8 @@ size_categories:
 
 This dataset contains the benchmark tasks for evaluating multi-agent coordination in code collaboration.
 
-**Paper**: [CooperBench: Why Coding Agents Cannot be Your Teammates Yet](https://arxiv.org/abs/2601.13295)  
-**Code**: [github.com/cooperbench/CooperBench](https://github.com/cooperbench/CooperBench)  
+**Paper**: [CooperBench: Why Coding Agents Cannot be Your Teammates Yet](https://arxiv.org/abs/2601.13295)
+**Code**: [github.com/cooperbench/CooperBench](https://github.com/cooperbench/CooperBench)
 **Website**: [cooperbench.com](https://cooperbench.com)
 
 ## Structure
@@ -65,7 +65,19 @@ Pre-defined task subsets are available in `subsets/` for quick evaluation:
 
 | Subset | Tasks | Pairs | Repos | Description |
 |--------|-------|-------|-------|-------------|
-| `lite` | 7 | 100 | 7 | Quick evaluation subset, supports up to 4 agents |
+| `lite` | 8 | 100 | 8 | Quick evaluation subset, uniform random selection |
+
+The `lite` subset is generated via uniform random sampling of whole tasks (deterministic with fixed seed):
+
+```python
+random.seed(190)  # fixed seed for reproducibility
+random.shuffle(all_tasks)
+selected = []
+for task in all_tasks:
+    if total_pairs + task.num_pairs <= 100:
+        selected.append(task)
+# Result: 8 tasks, 100 pairs, 8 repos
+```
 
 **Usage:**
 ```bash

--- a/dataset/subsets/lite.json
+++ b/dataset/subsets/lite.json
@@ -1,18 +1,19 @@
 {
   "name": "lite",
-  "description": "100-pair subset for quick evaluation, supports up to 4 agents",
+  "description": "100-pair subset for quick evaluation (uniform random selection, seed=190)",
   "stats": {
-    "tasks": 7,
+    "tasks": 8,
     "pairs": 100,
-    "repos": 7
+    "repos": 8
   },
   "tasks": [
+    {"repo": "dottxt_ai_outlines_task", "task_id": 1371},
+    {"repo": "dspy_task", "task_id": 8394},
+    {"repo": "go_chi_task", "task_id": 56},
+    {"repo": "huggingface_datasets_task", "task_id": 7309},
+    {"repo": "llama_index_task", "task_id": 17070},
+    {"repo": "pallets_jinja_task", "task_id": 1621},
     {"repo": "pillow_task", "task_id": 25},
-    {"repo": "huggingface_datasets_task", "task_id": 6252},
-    {"repo": "react_hook_form_task", "task_id": 85},
-    {"repo": "llama_index_task", "task_id": 17244},
-    {"repo": "dottxt_ai_outlines_task", "task_id": 1706},
-    {"repo": "go_chi_task", "task_id": 27},
-    {"repo": "dspy_task", "task_id": 8394}
+    {"repo": "react_hook_form_task", "task_id": 153}
   ]
 }


### PR DESCRIPTION
## Description

Switch lite subset from heuristic selection to uniform random sampling of tasks.

## Changes

- Update `dataset/subsets/lite.json` with uniform random task selection (seed=190)
- Add pseudocode explanation of selection method to `dataset/README.md`
- New stats: 8 tasks, 100 pairs, 8 repos (was 7/100/7)

## Checklist

- [x] Code follows project style
- [x] Tests pass locally
- [x] Documentation updated (if needed)