### PR TITLE
Fix OpenHands SDK Modal startup and full-eval reliability

### DIFF
--- a/src/cooperbench/agents/openhands_agent_sdk/openhands-sdk/openhands/sdk/conversation/event_store.py
+++ b/src/cooperbench/agents/openhands_agent_sdk/openhands-sdk/openhands/sdk/conversation/event_store.py
@@ -172,11 +172,11 @@ class EventLog(EventsListBase):
         return self._length
 
     def _path(self, idx: int, *, event_id: EventID | None = None) -> str:
-        return f"{self._dir}/{
-            EVENT_FILE_PATTERN.format(
-                idx=idx, event_id=event_id or self._idx_to_id[idx]
-            )
-        }"
+        filename = EVENT_FILE_PATTERN.format(
+            idx=idx,
+            event_id=event_id or self._idx_to_id[idx],
+        )
+        return f"{self._dir}/{filename}"
 
     def _scan_and_build_index(self) -> int:
         try:

--- a/src/cooperbench/agents/openhands_agent_sdk/openhands-sdk/openhands/sdk/observability/laminar.py
+++ b/src/cooperbench/agents/openhands_agent_sdk/openhands-sdk/openhands/sdk/observability/laminar.py
@@ -2,6 +2,8 @@ from collections.abc import Callable
 from typing import (
     Any,
     Literal,
+    ParamSpec,
+    TypeVar,
 )
 
 import litellm
@@ -18,6 +20,9 @@ from openhands.sdk.observability.utils import get_env
 
 
 logger = get_logger(__name__)
+
+P = ParamSpec("P")
+R = TypeVar("R")
 
 
 def maybe_init_laminar():
@@ -54,7 +59,7 @@ def maybe_init_laminar():
         )
 
 
-def observe[**P, R](
+def observe(
     *,
     name: str | None = None,
     session_id: str | None = None,

--- a/src/cooperbench/agents/openhands_agent_sdk/openhands-sdk/openhands/sdk/tool/tool.py
+++ b/src/cooperbench/agents/openhands_agent_sdk/openhands-sdk/openhands/sdk/tool/tool.py
@@ -5,6 +5,7 @@ from typing import (
     TYPE_CHECKING,
     Any,
     ClassVar,
+    Generic,
     Protocol,
     Self,
     TypeVar,
@@ -93,7 +94,7 @@ class ToolAnnotations(BaseModel):
     )
 
 
-class ToolExecutor[ActionT, ObservationT](ABC):
+class ToolExecutor(ABC, Generic[ActionT, ObservationT]):
     """Executor function type for a Tool."""
 
     @abstractmethod
@@ -145,7 +146,7 @@ class ExecutableTool(Protocol):
         ...
 
 
-class ToolDefinition[ActionT, ObservationT](DiscriminatedUnionMixin, ABC):
+class ToolDefinition(DiscriminatedUnionMixin, ABC, Generic[ActionT, ObservationT]):
     """Base class for all tool implementations.
 
     This class serves as a base for the discriminated union of all tool types.

--- a/src/cooperbench/agents/openhands_agent_sdk/openhands-sdk/openhands/sdk/utils/paging.py
+++ b/src/cooperbench/agents/openhands_agent_sdk/openhands-sdk/openhands/sdk/utils/paging.py
@@ -1,10 +1,13 @@
 """Pagination utilities for iterating over paginated search results."""
 
 from collections.abc import AsyncGenerator, Awaitable, Callable
-from typing import Any, Protocol
+from typing import Any, Protocol, TypeVar
 
 
-class PageProtocol[T](Protocol):
+T = TypeVar("T")
+
+
+class PageProtocol(Protocol[T]):
     """Protocol for page objects returned by search functions.
 
     All page objects should have:
@@ -16,7 +19,7 @@ class PageProtocol[T](Protocol):
     next_page_id: str | None
 
 
-async def page_iterator[T](
+async def page_iterator(
     search_func: Callable[..., Awaitable[PageProtocol[T]]],
     *args: Any,
     **kwargs: Any,

--- a/src/cooperbench/agents/openhands_agent_sdk/openhands-tools/openhands/tools/terminal/terminal/terminal_session.py
+++ b/src/cooperbench/agents/openhands_agent_sdk/openhands-tools/openhands/tools/terminal/terminal/terminal_session.py
@@ -429,11 +429,12 @@ class TerminalSession(TerminalSessionBase):
             logger.debug(
                 f"TERMINAL CONTENT GOT after {time.time() - _start_time:.2f} seconds"
             )
+            terminal_lines = cur_terminal_output.splitlines()
             logger.debug(
-                f"BEGIN OF TERMINAL CONTENT: {cur_terminal_output.split('\n')[:10]}"
+                f"BEGIN OF TERMINAL CONTENT: {terminal_lines[:10]}"
             )
             logger.debug(
-                f"END OF TERMINAL CONTENT: {cur_terminal_output.split('\n')[-10:]}"
+                f"END OF TERMINAL CONTENT: {terminal_lines[-10:]}"
             )
             ps1_matches = CmdOutputMetadata.matches_ps1_metadata(cur_terminal_output)
             current_ps1_count = len(ps1_matches)

--- a/src/cooperbench/eval/backends/modal.py
+++ b/src/cooperbench/eval/backends/modal.py
@@ -67,8 +67,13 @@ class ModalBackend:
         workdir: str = "/workspace",
     ) -> Sandbox:
         """Create a Modal sandbox for evaluation."""
+        # Eval runs need a stable long-running process for exec calls.
+        # Task images may have entrypoints that exit immediately, so clear it
+        # and run `sleep infinity` explicitly (mirrors Docker backend behavior).
         modal_image = modal.Image.from_registry(image).entrypoint([])
         sb = modal.Sandbox.create(
+            "sleep",
+            "infinity",
             image=modal_image,
             timeout=timeout,
             workdir=workdir,


### PR DESCRIPTION
## Summary
- preserve OpenHands `-oh` image entrypoint in the SDK adapter so agent-server starts correctly
- avoid repo import shadowing in OpenHands sandboxes by using `/` workdir
- make Modal eval backend use explicit keepalive startup (`entrypoint([])` + `sleep infinity`) for stable `sb.exec`
- update vendored OpenHands SDK/tools code for Python 3.11 compatibility

## Why
- fixes repeated `Modal Sandbox ... not found` failures during run/eval
- enables end-to-end reproduction of `gemini-3-flash` + `openhands_sdk` on full CooperBench

## Scope
- `src/cooperbench/agents/openhands_agent_sdk/adapter.py`
- `src/cooperbench/eval/backends/modal.py`
- vendored OpenHands SDK/tools compatibility fixes under `src/cooperbench/agents/openhands_agent_sdk/`

## Validation

Reproduced Gemini 3 Flash + OpenHands performance on CooperBench:
```
{
  "pass_rate": 0.2846153846153846,
  "total_runs": 652,
  "passed": 185,
  "failed": 465,
  "errors": 2,
  "skipped": 0,
}
```