### PR TITLE
Fix outlines task1706: pin transformers and tokenizers versions

### DIFF
--- a/dataset/dottxt_ai_outlines_task/task1706/Dockerfile
+++ b/dataset/dottxt_ai_outlines_task/task1706/Dockerfile
@@ -26,7 +26,7 @@ ENV LLAMA_CPP_FORCE_CPU=1
 ENV PYTORCH_ENABLE_MPS_FALLBACK=1
 RUN uv pip install --system -e . && \
     uv pip install --system pytest pytest-xdist pytest_mock pytest-asyncio pytest-benchmark pytest-cov && \
-    uv pip install --system torch transformers sentencepiece xgrammar llama-cpp-python==0.3.16 psutil
+    uv pip install --system torch "transformers<5" "tokenizers<0.21" sentencepiece xgrammar llama-cpp-python==0.3.16 psutil
 
 # Copy the runner script
 COPY runner.sh /usr/local/bin/

--- a/dataset/dottxt_ai_outlines_task/task1706/runner.sh
+++ b/dataset/dottxt_ai_outlines_task/task1706/runner.sh
@@ -67,7 +67,7 @@ echo "Installing dependencies..."
 uv sync 2>/dev/null || true
 uv pip install --system -e .
 uv pip install --system pytest pytest-xdist pytest_mock pytest-asyncio pytest-benchmark pytest-cov
-uv pip install --system torch transformers sentencepiece xgrammar llama-cpp-python==0.3.16 psutil
+uv pip install --system torch "transformers<5" "tokenizers<0.21" sentencepiece xgrammar llama-cpp-python==0.3.16 psutil
 
 # Run tests with timeout
 echo "Running tests..."


### PR DESCRIPTION
## Summary

The outlines task1706 Dockerfile and runner.sh install `transformers` and `tokenizers` without version pins. With the latest releases (`transformers>=5.0.0`, `tokenizers>=0.22`), all tests that use the `model_transformers` fixture fail:

- **`tokenizers>=0.22`** turns the `BPE.__init__` `DeprecationWarning` into a hard error, causing `GPT2Tokenizer` initialization to fail
- **`transformers>=5.0.0`** has a code path in `_from_pretrained` that calls `import_protobuf_decode_error()` inside an `except` clause, which raises `ImportError` when protobuf is not installed — even for non-protobuf tokenizers like GPT2

The pre-built Docker image (`akhatua/cooperbench-dottxt-ai-outlines:task1706`) ships with `transformers==5.0.0` + `tokenizers==0.22.2` and is affected by both issues — 8 of 9 tests error with `DeprecationWarning` / `ImportError` on every run.

### Fix

Pin `transformers<5` and `tokenizers<0.21` in both the Dockerfile and runner.sh.

### Verification

Built the fixed image locally and ran the full test suite against the oracle `combined.patch`:

- Feature 4 tests: **9/9 passed**
- Feature 6 tests: **11/11 passed**
- Full end-to-end (merge + both features via runner.sh): **reward=1**

The pre-built image also needs to be rebuilt with these pins.

## Test plan

- [x] Build fixed Docker image locally
- [x] Run feature 4 tests against oracle combined.patch → 9/9 passed
- [x] Run feature 6 tests against oracle combined.patch → 11/11 passed
- [x] Run full end-to-end test.sh (merge + both features) → reward=1
- [x] Confirm pre-built image (`akhatua/cooperbench-dottxt-ai-outlines:task1706`) reproduces the failure → 1 passed, 8 errors