### PR TITLE
Fix dspy task 8635: change min_instr_chars default from 30 to 0

### DIFF
--- a/dataset/dspy_task/task8635/combined.patch
+++ b/dataset/dspy_task/task8635/combined.patch
@@ -51,7 +51,7 @@ index 13722b4b..2d60a9b6 100644
          use_tip=True,
          verbose=False,
 +        max_description_chars=2000,
-+        min_instr_chars=30,
++        min_instr_chars=0,
 +        max_instr_chars=600,
 +        rephrase_when_too_long=False,
      ):
@@ -201,7 +201,7 @@ index 13722b4b..2d60a9b6 100644
 +        max_instruct_history=5,
 +        tip_weights=None,
 +        max_description_chars=2000,
-+        min_instr_chars=30,
++        min_instr_chars=0,
 +        max_instr_chars=600,
 +        rephrase_when_too_long=False,
      ):


### PR DESCRIPTION
## Summary
- The `combined.patch` for dspy task 8635 adds instruction length bounds to `GenerateModuleInstruction` and `GroundedProposer` with `min_instr_chars=30`
- The pre-existing test `test_propose_instructions_for_program[None]` uses `DummyLM({"proposed_instruction": "instruction"})` which returns `"instruction"` (11 chars)
- This falls below the 30-char minimum, causing the code to fall back to the default signature instruction (`"Given the fields 'question', produce the fields 'answer'."`)
- The assertion `pred_instructions == ["instruction"]` then fails
- `tests2.patch` already corrects this assertion, but `tests1.patch` does not — so feature 1 tests always fail when run against the combined implementation

## Fix
Change `min_instr_chars` default from `30` to `0` in both `GenerateModuleInstruction.__init__` and `GroundedProposer.__init__` within `combined.patch`. The length-bounds feature remains fully functional when explicitly configured, but the default no longer silently rejects short mock/test instructions.

## Test plan
- [x] Oracle test passes for dspy task 8635 (both features)
- [x] Verified on Modal with Harbor evaluation framework