### PR TITLE
Fix dspy task 8563: update TOOL_CALL_TEST_CASES in features 2-6 test patches

### DIFF
--- a/dataset/dspy_task/task8563/feature2/tests.patch
+++ b/dataset/dspy_task/task8563/feature2/tests.patch
@@ -2,7 +2,75 @@ diff --git a/tests/adapters/test_tool.py b/tests/adapters/test_tool.py
 index 18571453..8b16200b 100644
 --- a/tests/adapters/test_tool.py
 +++ b/tests/adapters/test_tool.py
-@@ -444,6 +444,81 @@ def test_tool_calls_format_basic(tool_calls_data, expected):
+@@ -5,7 +5,7 @@ import pytest
+ from pydantic import BaseModel
+ 
+ import dspy
+-from dspy.adapters.types.tool import Tool, ToolCalls
++from dspy.adapters.types.tool import Tool, ToolCalls, convert_input_schema_to_tool_args
+ 
+ 
+ # Test fixtures
+@@ -394,42 +394,33 @@ def test_async_tool_call_in_sync_mode():
+ 
+ 
+ TOOL_CALL_TEST_CASES = [
+-    ([], [{"type": "tool_calls", "tool_calls": []}]),
++    ([], {"tool_calls": []}),
+     (
+         [{"name": "search", "args": {"query": "hello"}}],
+-        [
+-            {
+-                "type": "tool_calls",
+-                "tool_calls": [{"type": "function", "function": {"name": "search", "arguments": {"query": "hello"}}}],
+-            }
+-        ],
++        {
++            "tool_calls": [{"type": "function", "function": {"name": "search", "arguments": {"query": "hello"}}}],
++        },
+     ),
+     (
+         [
+             {"name": "search", "args": {"query": "hello"}},
+             {"name": "translate", "args": {"text": "world", "lang": "fr"}},
+         ],
+-        [
+-            {
+-                "type": "tool_calls",
+-                "tool_calls": [
+-                    {"type": "function", "function": {"name": "search", "arguments": {"query": "hello"}}},
+-                    {
+-                        "type": "function",
+-                        "function": {"name": "translate", "arguments": {"text": "world", "lang": "fr"}},
+-                    },
+-                ],
+-            }
+-        ],
++        {
++            "tool_calls": [
++                {"type": "function", "function": {"name": "search", "arguments": {"query": "hello"}}},
++                {
++                    "type": "function",
++                    "function": {"name": "translate", "arguments": {"text": "world", "lang": "fr"}},
++                },
++            ],
++        },
+     ),
+     (
+         [{"name": "get_time", "args": {}}],
+-        [
+-            {
+-                "type": "tool_calls",
+-                "tool_calls": [{"type": "function", "function": {"name": "get_time", "arguments": {}}}],
+-            }
+-        ],
++        {
++            "tool_calls": [{"type": "function", "function": {"name": "get_time", "arguments": {}}}],
++        },
+     ),
+ ]
+ 
+@@ -444,6 +435,81 @@ def test_tool_calls_format_basic(tool_calls_data, expected):
      assert result == expected
  
  

--- a/dataset/dspy_task/task8563/feature3/tests.patch
+++ b/dataset/dspy_task/task8563/feature3/tests.patch
@@ -2,7 +2,75 @@ diff --git a/tests/adapters/test_tool.py b/tests/adapters/test_tool.py
 index 18571453..26eb0028 100644
 --- a/tests/adapters/test_tool.py
 +++ b/tests/adapters/test_tool.py
-@@ -434,6 +434,117 @@ TOOL_CALL_TEST_CASES = [
+@@ -5,7 +5,7 @@ import pytest
+ from pydantic import BaseModel
+ 
+ import dspy
+-from dspy.adapters.types.tool import Tool, ToolCalls
++from dspy.adapters.types.tool import Tool, ToolCalls, convert_input_schema_to_tool_args
+ 
+ 
+ # Test fixtures
+@@ -394,42 +394,33 @@ def test_async_tool_call_in_sync_mode():
+ 
+ 
+ TOOL_CALL_TEST_CASES = [
+-    ([], [{"type": "tool_calls", "tool_calls": []}]),
++    ([], {"tool_calls": []}),
+     (
+         [{"name": "search", "args": {"query": "hello"}}],
+-        [
+-            {
+-                "type": "tool_calls",
+-                "tool_calls": [{"type": "function", "function": {"name": "search", "arguments": {"query": "hello"}}}],
+-            }
+-        ],
++        {
++            "tool_calls": [{"type": "function", "function": {"name": "search", "arguments": {"query": "hello"}}}],
++        },
+     ),
+     (
+         [
+             {"name": "search", "args": {"query": "hello"}},
+             {"name": "translate", "args": {"text": "world", "lang": "fr"}},
+         ],
+-        [
+-            {
+-                "type": "tool_calls",
+-                "tool_calls": [
+-                    {"type": "function", "function": {"name": "search", "arguments": {"query": "hello"}}},
+-                    {
+-                        "type": "function",
+-                        "function": {"name": "translate", "arguments": {"text": "world", "lang": "fr"}},
+-                    },
+-                ],
+-            }
+-        ],
++        {
++            "tool_calls": [
++                {"type": "function", "function": {"name": "search", "arguments": {"query": "hello"}}},
++                {
++                    "type": "function",
++                    "function": {"name": "translate", "arguments": {"text": "world", "lang": "fr"}},
++                },
++            ],
++        },
+     ),
+     (
+         [{"name": "get_time", "args": {}}],
+-        [
+-            {
+-                "type": "tool_calls",
+-                "tool_calls": [{"type": "function", "function": {"name": "get_time", "arguments": {}}}],
+-            }
+-        ],
++        {
++            "tool_calls": [{"type": "function", "function": {"name": "get_time", "arguments": {}}}],
++        },
+     ),
+ ]
+ 
+@@ -434,6 +425,117 @@ TOOL_CALL_TEST_CASES = [
  ]
  
  

--- a/dataset/dspy_task/task8563/feature4/tests.patch
+++ b/dataset/dspy_task/task8563/feature4/tests.patch
@@ -2,7 +2,75 @@ diff --git a/tests/adapters/test_tool.py b/tests/adapters/test_tool.py
 index 18571453..183f8725 100644
 --- a/tests/adapters/test_tool.py
 +++ b/tests/adapters/test_tool.py
-@@ -170,6 +170,155 @@ def test_tool_from_function_with_pydantic():
+@@ -5,7 +5,7 @@ import pytest
+ from pydantic import BaseModel
+ 
+ import dspy
+-from dspy.adapters.types.tool import Tool, ToolCalls
++from dspy.adapters.types.tool import Tool, ToolCalls, convert_input_schema_to_tool_args
+ 
+ 
+ # Test fixtures
+@@ -394,42 +394,33 @@ def test_async_tool_call_in_sync_mode():
+ 
+ 
+ TOOL_CALL_TEST_CASES = [
+-    ([], [{"type": "tool_calls", "tool_calls": []}]),
++    ([], {"tool_calls": []}),
+     (
+         [{"name": "search", "args": {"query": "hello"}}],
+-        [
+-            {
+-                "type": "tool_calls",
+-                "tool_calls": [{"type": "function", "function": {"name": "search", "arguments": {"query": "hello"}}}],
+-            }
+-        ],
++        {
++            "tool_calls": [{"type": "function", "function": {"name": "search", "arguments": {"query": "hello"}}}],
++        },
+     ),
+     (
+         [
+             {"name": "search", "args": {"query": "hello"}},
+             {"name": "translate", "args": {"text": "world", "lang": "fr"}},
+         ],
+-        [
+-            {
+-                "type": "tool_calls",
+-                "tool_calls": [
+-                    {"type": "function", "function": {"name": "search", "arguments": {"query": "hello"}}},
+-                    {
+-                        "type": "function",
+-                        "function": {"name": "translate", "arguments": {"text": "world", "lang": "fr"}},
+-                    },
+-                ],
+-            }
+-        ],
++        {
++            "tool_calls": [
++                {"type": "function", "function": {"name": "search", "arguments": {"query": "hello"}}},
++                {
++                    "type": "function",
++                    "function": {"name": "translate", "arguments": {"text": "world", "lang": "fr"}},
++                },
++            ],
++        },
+     ),
+     (
+         [{"name": "get_time", "args": {}}],
+-        [
+-            {
+-                "type": "tool_calls",
+-                "tool_calls": [{"type": "function", "function": {"name": "get_time", "arguments": {}}}],
+-            }
+-        ],
++        {
++            "tool_calls": [{"type": "function", "function": {"name": "get_time", "arguments": {}}}],
++        },
+     ),
+ ]
+ 
+@@ -170,6 +161,155 @@ def test_tool_from_function_with_pydantic():
      assert tool.args["model"]["properties"]["field1"]["default"] == "hello"
  
  

--- a/dataset/dspy_task/task8563/feature5/tests.patch
+++ b/dataset/dspy_task/task8563/feature5/tests.patch
@@ -2,7 +2,75 @@ diff --git a/tests/adapters/test_tool.py b/tests/adapters/test_tool.py
 index 18571453..4a34c5e8 100644
 --- a/tests/adapters/test_tool.py
 +++ b/tests/adapters/test_tool.py
-@@ -217,6 +217,262 @@ def test_parameter_desc():
+@@ -5,7 +5,7 @@ import pytest
+ from pydantic import BaseModel
+ 
+ import dspy
+-from dspy.adapters.types.tool import Tool, ToolCalls
++from dspy.adapters.types.tool import Tool, ToolCalls, convert_input_schema_to_tool_args
+ 
+ 
+ # Test fixtures
+@@ -394,42 +394,33 @@ def test_async_tool_call_in_sync_mode():
+ 
+ 
+ TOOL_CALL_TEST_CASES = [
+-    ([], [{"type": "tool_calls", "tool_calls": []}]),
++    ([], {"tool_calls": []}),
+     (
+         [{"name": "search", "args": {"query": "hello"}}],
+-        [
+-            {
+-                "type": "tool_calls",
+-                "tool_calls": [{"type": "function", "function": {"name": "search", "arguments": {"query": "hello"}}}],
+-            }
+-        ],
++        {
++            "tool_calls": [{"type": "function", "function": {"name": "search", "arguments": {"query": "hello"}}}],
++        },
+     ),
+     (
+         [
+             {"name": "search", "args": {"query": "hello"}},
+             {"name": "translate", "args": {"text": "world", "lang": "fr"}},
+         ],
+-        [
+-            {
+-                "type": "tool_calls",
+-                "tool_calls": [
+-                    {"type": "function", "function": {"name": "search", "arguments": {"query": "hello"}}},
+-                    {
+-                        "type": "function",
+-                        "function": {"name": "translate", "arguments": {"text": "world", "lang": "fr"}},
+-                    },
+-                ],
+-            }
+-        ],
++        {
++            "tool_calls": [
++                {"type": "function", "function": {"name": "search", "arguments": {"query": "hello"}}},
++                {
++                    "type": "function",
++                    "function": {"name": "translate", "arguments": {"text": "world", "lang": "fr"}},
++                },
++            ],
++        },
+     ),
+     (
+         [{"name": "get_time", "args": {}}],
+-        [
+-            {
+-                "type": "tool_calls",
+-                "tool_calls": [{"type": "function", "function": {"name": "get_time", "arguments": {}}}],
+-            }
+-        ],
++        {
++            "tool_calls": [{"type": "function", "function": {"name": "get_time", "arguments": {}}}],
++        },
+     ),
+ ]
+ 
+@@ -217,6 +208,262 @@ def test_parameter_desc():
      assert tool.args["x"]["description"] == "The x parameter"
  
  

--- a/dataset/dspy_task/task8563/feature6/tests.patch
+++ b/dataset/dspy_task/task8563/feature6/tests.patch
@@ -2,7 +2,75 @@ diff --git a/tests/adapters/test_tool.py b/tests/adapters/test_tool.py
 index 18571453..f3823a50 100644
 --- a/tests/adapters/test_tool.py
 +++ b/tests/adapters/test_tool.py
-@@ -55,6 +55,129 @@ class Note(BaseModel):
+@@ -5,7 +5,7 @@ import pytest
+ from pydantic import BaseModel
+ 
+ import dspy
+-from dspy.adapters.types.tool import Tool, ToolCalls
++from dspy.adapters.types.tool import Tool, ToolCalls, convert_input_schema_to_tool_args
+ 
+ 
+ # Test fixtures
+@@ -394,42 +394,33 @@ def test_async_tool_call_in_sync_mode():
+ 
+ 
+ TOOL_CALL_TEST_CASES = [
+-    ([], [{"type": "tool_calls", "tool_calls": []}]),
++    ([], {"tool_calls": []}),
+     (
+         [{"name": "search", "args": {"query": "hello"}}],
+-        [
+-            {
+-                "type": "tool_calls",
+-                "tool_calls": [{"type": "function", "function": {"name": "search", "arguments": {"query": "hello"}}}],
+-            }
+-        ],
++        {
++            "tool_calls": [{"type": "function", "function": {"name": "search", "arguments": {"query": "hello"}}}],
++        },
+     ),
+     (
+         [
+             {"name": "search", "args": {"query": "hello"}},
+             {"name": "translate", "args": {"text": "world", "lang": "fr"}},
+         ],
+-        [
+-            {
+-                "type": "tool_calls",
+-                "tool_calls": [
+-                    {"type": "function", "function": {"name": "search", "arguments": {"query": "hello"}}},
+-                    {
+-                        "type": "function",
+-                        "function": {"name": "translate", "arguments": {"text": "world", "lang": "fr"}},
+-                    },
+-                ],
+-            }
+-        ],
++        {
++            "tool_calls": [
++                {"type": "function", "function": {"name": "search", "arguments": {"query": "hello"}}},
++                {
++                    "type": "function",
++                    "function": {"name": "translate", "arguments": {"text": "world", "lang": "fr"}},
++                },
++            ],
++        },
+     ),
+     (
+         [{"name": "get_time", "args": {}}],
+-        [
+-            {
+-                "type": "tool_calls",
+-                "tool_calls": [{"type": "function", "function": {"name": "get_time", "arguments": {}}}],
+-            }
+-        ],
++        {
++            "tool_calls": [{"type": "function", "function": {"name": "get_time", "arguments": {}}}],
++        },
+     ),
+ ]
+ 
+@@ -55,6 +46,129 @@ class Note(BaseModel):
      author: str
  
  


### PR DESCRIPTION
## Summary
- The `combined.patch` changes `ToolCalls.format()` return type from `list[dict]` to `dict` when no metadata is present
- Feature 1's test patch correctly updates `TOOL_CALL_TEST_CASES` expectations and `test_tool_calls_format_from_dict_list` assertions to match the new dict format
- Features 2–6 test patches do **not** include this update
- Since each feature's tests run against the full merged implementation (via `runner.sh tests_patch merged.patch`), the pre-existing `test_tool_calls_format_basic[tool_calls_data0-expected0]` fails whenever features 2–6 tests run — the test still expects the old list format but `format()` now returns a dict

## Fix
Add the following updates from feature 1's test patch to features 2–6:
1. Import update: add `convert_input_schema_to_tool_args` to the import line
2. `TOOL_CALL_TEST_CASES` data update: `[{"type": "tool_calls", ...}]` → `{"tool_calls": [...]}`
3. `test_tool_calls_format_from_dict_list` assertion update: `result[0]["tool_calls"]` → `result["tool_calls"]`

## Test plan
- [x] Oracle test passes for all dspy task 8563 feature pairs (including f2-4 which previously failed)
- [x] Verified on Modal with Harbor evaluation framework