### PR TITLE
Fix datasets task 7309: pin pyarrow < 20.0 for geoparquet compatibility

### DIFF
--- a/dataset/huggingface_datasets_task/task7309/Dockerfile
+++ b/dataset/huggingface_datasets_task/task7309/Dockerfile
@@ -20,7 +20,7 @@ RUN git clone https://github.com/huggingface/datasets.git repo && \
 # Set up Python environment and pre-install dependencies
 WORKDIR /workspace/repo
 RUN uv pip install --system -e .
-RUN uv pip uninstall --system pyarrow && uv pip install --system "pyarrow==20.0.0"
+RUN uv pip uninstall --system pyarrow && uv pip install --system "pyarrow>=17.0.0,<20.0.0"
 # Install tensorflow, explicitly excluding tensorflow-macos (macOS-only package)
 RUN uv pip install --system "tensorflow>=2.16.0,<2.17.0" || uv pip install --system "tensorflow==2.16.2"
 RUN uv pip install --system torch jax


### PR DESCRIPTION
## Summary
- The Dockerfile for datasets task 7309 pins `pyarrow==20.0.0`
- PyArrow 20.0 changed the default Arrow string type mapping, causing geoparquet geometry columns to report as `large_string` instead of `string`
- The pre-existing test `test_parquet_read_geoparquet` asserts `dataset.features[feature].dtype == 'string'`, which fails with `large_string`
- This breaks **all** feature pairs for this task (both feature 1 and feature 2 tests fail on the same pre-existing test)

## Fix
Change the pyarrow pin in the Dockerfile from:
```dockerfile
RUN uv pip uninstall --system pyarrow && uv pip install --system "pyarrow==20.0.0"
```
to:
```dockerfile
RUN uv pip uninstall --system pyarrow && uv pip install --system "pyarrow>=17.0.0,<20.0.0"
```

The Docker image (`akhatua/cooperbench-huggingface-datasets:task7309`) needs to be rebuilt and pushed to DockerHub after this change.

## Test plan
- [ ] Rebuild Docker image with pinned pyarrow
- [ ] Oracle test passes for datasets task 7309 (both features)