### PR TITLE
Fix tiktoken task0/feature3: parameter name mismatch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,18 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.0.6] - 2026-04-17
+
+### Added
+
+- **`cooperbench prepare`** - New CLI subcommand that downloads the benchmark dataset from HuggingFace (`CodeConflict/cooperbench-dataset`) into `./dataset`, so PyPI users don't need to clone the GitHub repo
+- **`scripts/upload_dataset_to_hf.py`** - Maintainer script to sync the local `dataset/` tree up to the HuggingFace dataset repo
+
+### Changed
+
+- **README** - Replaced `git clone` dataset instructions with `cooperbench prepare`; fixed stale HuggingFace URL
+- Added `huggingface-hub>=0.24` as a core dependency
+
 ## [0.0.5] - 2026-02-14
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![arXiv](https://img.shields.io/badge/arXiv-2601.13295-b31b1b.svg)](https://arxiv.org/abs/2601.13295)
 [![Website](https://img.shields.io/badge/Website-cooperbench.com-blue.svg)](https://cooperbench.com)
-[![Dataset](https://img.shields.io/badge/HuggingFace-Dataset-yellow.svg)](https://huggingface.co/datasets/cooperbench/cooperbench)
+[![Dataset](https://img.shields.io/badge/HuggingFace-Dataset-yellow.svg)](https://huggingface.co/datasets/CodeConflict/cooperbench-dataset)
 [![PyPI](https://img.shields.io/pypi/v/cooperbench.svg)](https://pypi.org/project/cooperbench/)
 [![License: MIT](https://img.shields.io/badge/License-MIT-green.svg)](https://opensource.org/licenses/MIT)
 
@@ -71,10 +71,10 @@ See [GCP Setup Guide](docs/GCP_SETUP.md) for detailed instructions.
 
 ### Dataset
 
-Download the benchmark dataset:
+Download the benchmark dataset from HuggingFace into `./dataset`:
 
 ```bash
-git clone https://huggingface.co/datasets/cooperbench/cooperbench dataset/
+cooperbench prepare
 ```
 
 ## Quick Start

--- a/dataset/openai_tiktoken_task/task0/feature3/feature.patch
+++ b/dataset/openai_tiktoken_task/task0/feature3/feature.patch
@@ -27,7 +27,7 @@ index 6bc9736..779cf03 100644
          allowed_special: Literal["all"] | AbstractSet[str] = set(),  # noqa: B006
          disallowed_special: Literal["all"] | Collection[str] = "all",
 -    ) -> list[int]:
-+        return_frequency: bool = False,
++        analyze_frequency: bool = False,
 +    ) -> Union[list[int], Tuple[list[int], Dict[int, int]]]:
          """Encodes a string into tokens.
  
@@ -36,7 +36,7 @@ index 6bc9736..779cf03 100644
            cause all text corresponding to special tokens to be encoded as natural text.
          - Setting `allowed_special` to "all" will cause this function to treat all text
            corresponding to special tokens to be encoded as special tokens.
-+        - Setting `return_frequency` to True will return a tuple of (tokens, frequencies), where
++        - Setting `analyze_frequency` to True will return a tuple of (tokens, frequencies), where
 +          frequencies is a dict mapping token IDs to their frequencies.
  
          ```
@@ -45,7 +45,7 @@ index 6bc9736..779cf03 100644
          # Raises ValueError
          >>> enc.encode("<|endoftext|>", disallowed_special=())
          [27, 91, 437, 1659, 5239, 91, 29]
-+        >>> enc.encode("hello world", return_frequency=True)
++        >>> enc.encode("hello world", analyze_frequency=True)
 +        ([31373, 995], {31373: 1, 995: 1})
          ```
          """
@@ -67,7 +67,7 @@ index 6bc9736..779cf03 100644
 -
 +            tokens = self._core_bpe.encode(text, allowed_special)
 + 
-+        if return_frequency:
++        if analyze_frequency:
 +            frequencies = self._count_token_frequency(tokens)
 +            return tokens, frequencies
 + 

--- a/dataset/openai_tiktoken_task/task0/feature3/tests.patch
+++ b/dataset/openai_tiktoken_task/task0/feature3/tests.patch
@@ -13,21 +13,21 @@ index 0000000..bcaceb8
 + 
 +    # Test basic frequency counting
 +    text = "abcabcabc"
-+    tokens, freq = enc.encode(text, return_frequency=True)
++    tokens, freq = enc.encode(text, analyze_frequency=True)
 +    assert freq == {13997: 3}  # Each token appears 3 times
 + 
 +    # Test with repeated tokens
 +    text = "aaabbbccc"
-+    tokens, freq = enc.encode(text, return_frequency=True)
++    tokens, freq = enc.encode(text, analyze_frequency=True)
 +    assert freq == {370: 1, 5418: 1, 6194: 1, 38154: 1}
 + 
 +    # Test with single token
 +    text = "aaa"
-+    tokens, freq = enc.encode(text, return_frequency=True)
++    tokens, freq = enc.encode(text, analyze_frequency=True)
 +    assert freq == {33746: 1}
 + 
 +    # Test empty input
 +    text = ""
-+    tokens, freq = enc.encode(text, return_frequency=True)
++    tokens, freq = enc.encode(text, analyze_frequency=True)
 +    assert freq == {}
 \ No newline at end of file

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -75,6 +75,7 @@ dependencies = [
     "libtmux>=0.53.0",
     "func-timeout>=4.3.5",
     "tom-swe>=1.0.3",
+    "huggingface-hub>=0.24",
 ]
 
 [project.optional-dependencies]

--- a/scripts/upload_dataset_to_hf.py
+++ b/scripts/upload_dataset_to_hf.py
@@ -1,0 +1,73 @@
+"""Sync the local `dataset/` directory to the HuggingFace dataset repo.
+
+Mirrors `dataset/` 1:1 into `CodeConflict/cooperbench-dataset`. The local
+README.md becomes the HF repo's dataset card.
+
+Usage:
+    python scripts/upload_dataset_to_hf.py
+    python scripts/upload_dataset_to_hf.py --commit-message "Add task 9999"
+    python scripts/upload_dataset_to_hf.py --create-pr
+
+Auth:
+    Requires HF_TOKEN env var (or a prior `huggingface-cli login`) with write
+    access to the target repo.
+"""
+
+import argparse
+import os
+import sys
+from pathlib import Path
+
+from huggingface_hub import HfApi, create_repo
+
+REPO_ID = "CodeConflict/cooperbench-dataset"
+LOCAL_DIR = Path(__file__).resolve().parent.parent / "dataset"
+IGNORE_PATTERNS = [
+    "**/__pycache__/**",
+    "**/.DS_Store",
+    "**/*.pyc",
+]
+
+
+def parse_args() -> argparse.Namespace:
+    p = argparse.ArgumentParser(description=__doc__)
+    p.add_argument(
+        "--commit-message",
+        default="Update dataset",
+        help="Commit message for the HF revision.",
+    )
+    p.add_argument(
+        "--create-pr",
+        action="store_true",
+        help="Open a PR on the dataset repo instead of committing to main.",
+    )
+    return p.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+
+    if not LOCAL_DIR.is_dir():
+        print(f"error: {LOCAL_DIR} is not a directory", file=sys.stderr)
+        return 1
+
+    token = os.environ.get("HF_TOKEN")
+    print(f"local dir:     {LOCAL_DIR}")
+    print(f"repo:          {REPO_ID} (dataset)")
+
+    create_repo(repo_id=REPO_ID, repo_type="dataset", exist_ok=True, token=token)
+
+    result = HfApi(token=token).upload_folder(
+        repo_id=REPO_ID,
+        repo_type="dataset",
+        folder_path=str(LOCAL_DIR),
+        commit_message=args.commit_message,
+        create_pr=args.create_pr,
+        ignore_patterns=IGNORE_PATTERNS,
+    )
+    print(f"done: {result}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/cooperbench/__about__.py
+++ b/src/cooperbench/__about__.py
@@ -1,3 +1,3 @@
 """Version information for CooperBench."""
 
-__version__ = "0.0.5"
+__version__ = "0.0.6"

--- a/src/cooperbench/cli.py
+++ b/src/cooperbench/cli.py
@@ -1,6 +1,7 @@
 """CooperBench CLI - benchmark runner.
 
 Usage:
+    cooperbench prepare                       # download dataset from HuggingFace
     cooperbench run -n my-experiment --setting solo -r llama_index_task
     cooperbench run --setting solo -s lite  # auto-generates name: solo-lite-gemini-3-flash
     cooperbench eval -n my-experiment --force
@@ -63,6 +64,21 @@ def main():
         description="CooperBench benchmark runner",
     )
     subparsers = parser.add_subparsers(dest="command", required=True)
+
+    # === prepare command ===
+    prepare_parser = subparsers.add_parser(
+        "prepare",
+        help="Download the CooperBench dataset from HuggingFace",
+        description=(
+            "Download the CooperBench dataset (CodeConflict/cooperbench-dataset) "
+            "into ./dataset so `run`/`eval` can use it."
+        ),
+    )
+    prepare_parser.add_argument(
+        "--force",
+        action="store_true",
+        help="Delete ./dataset before downloading.",
+    )
 
     # === config command ===
     config_parser = subparsers.add_parser(
@@ -242,6 +258,10 @@ def main():
         _run_command(args)
     elif args.command == "eval":
         _eval_command(args)
+    elif args.command == "prepare":
+        from cooperbench.dataset import _prepare_command
+
+        _prepare_command(args)
 
 
 def _config_command(args):

--- a/src/cooperbench/dataset.py
+++ b/src/cooperbench/dataset.py
@@ -1,0 +1,51 @@
+"""Prepare the CooperBench dataset locally from the HuggingFace mirror.
+
+Downloads every file of `CodeConflict/cooperbench-dataset` into `./dataset`,
+reproducing the layout expected by `cooperbench run` / `cooperbench eval`.
+"""
+
+from __future__ import annotations
+
+import os
+import shutil
+import sys
+from pathlib import Path
+
+from huggingface_hub import snapshot_download
+
+REPO_ID = "CodeConflict/cooperbench-dataset"
+
+
+def prepare_dataset(force: bool = False) -> Path:
+    """Download the CooperBench dataset into `./dataset`."""
+    dest = Path.cwd() / "dataset"
+
+    if dest.exists() and force:
+        print(f"removing existing {dest}")
+        shutil.rmtree(dest)
+
+    dest.mkdir(parents=True, exist_ok=True)
+
+    print(f"repo:          {REPO_ID}")
+    print(f"destination:   {dest}")
+
+    snapshot_download(
+        repo_id=REPO_ID,
+        repo_type="dataset",
+        local_dir=str(dest),
+        token=os.environ.get("HF_TOKEN"),
+    )
+
+    # snapshot_download creates `.cache/huggingface/` inside local_dir for bookkeeping; exclude it from the summary.
+    files = [p for p in dest.rglob("*") if p.is_file() and ".cache" not in p.parts]
+    total = sum(p.stat().st_size for p in files)
+    print(f"done: {len(files)} files, {total / 1e6:.2f} MB at {dest}")
+    return dest
+
+
+def _prepare_command(args) -> None:
+    try:
+        prepare_dataset(force=args.force)
+    except Exception as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        sys.exit(1)

--- a/uv.lock
+++ b/uv.lock
@@ -547,6 +547,7 @@ dependencies = [
     { name = "google-auth" },
     { name = "google-cloud-aiplatform" },
     { name = "httpx" },
+    { name = "huggingface-hub" },
     { name = "jinja2" },
     { name = "libtmux" },
     { name = "litellm" },
@@ -627,6 +628,7 @@ requires-dist = [
     { name = "google-cloud-storage", marker = "extra == 'all'", specifier = ">=2.0" },
     { name = "google-cloud-storage", marker = "extra == 'gcp'", specifier = ">=2.0" },
     { name = "httpx", specifier = ">=0.27.0" },
+    { name = "huggingface-hub", specifier = ">=0.24" },
     { name = "jinja2", specifier = ">=3.0" },
     { name = "libtmux", specifier = ">=0.53.0" },
     { name = "litellm", specifier = ">=1.0" },
@@ -4116,8 +4118,8 @@ name = "taskgroup"
 version = "0.2.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "exceptiongroup", marker = "python_full_version < '3.13'" },
-    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+    { name = "exceptiongroup", marker = "python_full_version < '3.11'" },
+    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/f0/8d/e218e0160cc1b692e6e0e5ba34e8865dbb171efeb5fc9a704544b3020605/taskgroup-0.2.2.tar.gz", hash = "sha256:078483ac3e78f2e3f973e2edbf6941374fbea81b9c5d0a96f51d297717f4752d", size = 11504, upload-time = "2025-01-03T09:24:13.761Z" }
 wheels = [


### PR DESCRIPTION
## Summary

Big thanks to @Oscillater for finding this one (#44)!

The `feature.md` spec for `openai_tiktoken_task/task0/feature3` uses `analyze_frequency` as the parameter name, but the reference patches (`feature.patch` and `tests.patch`) both used `return_frequency`. Updated the patches to use `analyze_frequency` to match the spec.

## Left to do

- [ ] Rerun evals for affected submissions on this task pair
- [ ] Update leaderboard