### PR TITLE
v0.0.7: docker by default + fix auto-eval backend passthrough

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.0.7] - 2026-04-17
+
+### Changed
+
+- **Docker is now the default backend** for both `cooperbench run` and `cooperbench eval`, as well as every helper API (`evaluate`, `_evaluate_single`, `run_patch_test`, `test_merged`, `test_solo`, `get_backend`, `get_environment`, agent adapter config fallbacks, and the coop/solo runners). Previously defaulted to `modal`.
+
+### Fixed
+
+- **Auto-eval now honours `--backend`** - `cooperbench run --backend <X>` no longer silently falls back to modal during the inline evaluation phase; the value is threaded through both the single-task and multi-task auto-eval paths (`runner/core.py`).
+
 ## [0.0.6] - 2026-04-17
 
 ### Added

--- a/src/cooperbench/__about__.py
+++ b/src/cooperbench/__about__.py
@@ -1,3 +1,3 @@
 """Version information for CooperBench."""
 
-__version__ = "0.0.6"
+__version__ = "0.0.7"

--- a/src/cooperbench/agents/mini_swe_agent/adapter.py
+++ b/src/cooperbench/agents/mini_swe_agent/adapter.py
@@ -68,7 +68,7 @@ class MiniSweAgentRunner:
             default_config.update(config)
 
         agent_config = default_config.get("agent", {})
-        backend = default_config.get("backend", "modal")
+        backend = default_config.get("backend", "docker")
 
         # Create sandbox environment based on backend
         if backend == "docker":

--- a/src/cooperbench/agents/mini_swe_agent/environments/__init__.py
+++ b/src/cooperbench/agents/mini_swe_agent/environments/__init__.py
@@ -5,7 +5,7 @@ from cooperbench.agents.mini_swe_agent.environments.modal import ModalEnvironmen
 __all__ = ["ModalEnvironment", "get_environment"]
 
 
-def get_environment(name: str = "modal"):
+def get_environment(name: str = "docker"):
     """Get an environment by name.
 
     Args:

--- a/src/cooperbench/agents/mini_swe_agent_v2/adapter.py
+++ b/src/cooperbench/agents/mini_swe_agent_v2/adapter.py
@@ -49,7 +49,7 @@ class MiniSweAgentV2Runner:
         agent_cfg = default_config.get("agent", {})
         model_cfg = default_config.get("model", {})
         env_cfg = default_config.get("environment", {})
-        backend = default_config.get("backend", "modal")
+        backend = default_config.get("backend", "docker")
 
         # Create environment based on backend
         env_kwargs = {

--- a/src/cooperbench/cli.py
+++ b/src/cooperbench/cli.py
@@ -191,8 +191,8 @@ def main():
     run_parser.add_argument(
         "--backend",
         choices=["modal", "docker", "gcp"],
-        default="modal",
-        help="Execution backend: modal (cloud), docker (local), or gcp (GCP VM) (default: modal)",
+        default="docker",
+        help="Execution backend: modal (cloud), docker (local), or gcp (GCP VM) (default: docker)",
     )
     run_parser.add_argument(
         "--agent-config",
@@ -246,8 +246,8 @@ def main():
     eval_parser.add_argument(
         "--backend",
         choices=["modal", "docker", "gcp"],
-        default="modal",
-        help="Execution backend: modal (cloud), docker (local), or gcp (GCP Batch) (default: modal)",
+        default="docker",
+        help="Execution backend: modal (cloud), docker (local), or gcp (GCP Batch) (default: docker)",
     )
 
     args = parser.parse_args()

--- a/src/cooperbench/eval/backends/__init__.py
+++ b/src/cooperbench/eval/backends/__init__.py
@@ -13,7 +13,7 @@ __all__ = [
 ]
 
 
-def get_backend(name: str = "modal") -> EvalBackend:
+def get_backend(name: str = "docker") -> EvalBackend:
     """Get an evaluation backend by name.
 
     For interactive/adhoc evaluation (Docker, Modal).

--- a/src/cooperbench/eval/evaluate.py
+++ b/src/cooperbench/eval/evaluate.py
@@ -21,7 +21,7 @@ def evaluate(
     features: list[int] | None = None,
     concurrency: int = 10,
     force: bool = False,
-    backend: str = "modal",
+    backend: str = "docker",
 ) -> None:
     """Evaluate completed runs.
 
@@ -269,7 +269,7 @@ def _run_gcp_batch(runs: list[dict], parallelism: int, force: bool) -> tuple:
     return passed, failed, errors, skipped, results
 
 
-def _evaluate_single(run_info: dict, force: bool = False, backend: str = "modal") -> dict | None:
+def _evaluate_single(run_info: dict, force: bool = False, backend: str = "docker") -> dict | None:
     """Evaluate a single run."""
     log_dir = Path(run_info["log_dir"])
     eval_file = log_dir / "eval.json"

--- a/src/cooperbench/eval/sandbox.py
+++ b/src/cooperbench/eval/sandbox.py
@@ -15,7 +15,7 @@ def run_patch_test(
     feature_id: int,
     agent_patch: str | Path | None = None,
     timeout: int = 600,
-    backend: str = "modal",
+    backend: str = "docker",
 ) -> dict:
     """Test a single patch against one feature's tests.
 
@@ -94,7 +94,7 @@ def test_merged(
     patch1: str | Path | None = None,
     patch2: str | Path | None = None,
     timeout: int = 600,
-    backend: str = "modal",
+    backend: str = "docker",
 ) -> dict:
     """Test merged patches from two agents (coop mode).
 
@@ -222,7 +222,7 @@ def test_solo(
     feature2_id: int,
     patch: str | Path | None = None,
     timeout: int = 600,
-    backend: str = "modal",
+    backend: str = "docker",
 ) -> dict:
     """Test a solo patch against both features' tests.
 

--- a/src/cooperbench/runner/coop.py
+++ b/src/cooperbench/runner/coop.py
@@ -28,7 +28,7 @@ def execute_coop(
     quiet: bool = False,
     git_enabled: bool = False,
     messaging_enabled: bool = True,
-    backend: str = "modal",
+    backend: str = "docker",
     agent_config: str | None = None,
 ) -> dict | None:
     """Execute a cooperative task (two agents, separate features).
@@ -237,7 +237,7 @@ def _spawn_agent(
     git_network: str | None = None,
     messaging_enabled: bool = True,
     quiet: bool = False,
-    backend: str = "modal",
+    backend: str = "docker",
     agent_config: str | None = None,
     run_name: str | None = None,
     features: list[int] | None = None,

--- a/src/cooperbench/runner/core.py
+++ b/src/cooperbench/runner/core.py
@@ -53,7 +53,7 @@ def run(
     messaging_enabled: bool = True,
     auto_eval: bool = True,
     eval_concurrency: int = 10,
-    backend: str = "modal",
+    backend: str = "docker",
     agent_config: str | None = None,
 ) -> None:
     """Run benchmark tasks.
@@ -160,7 +160,7 @@ def run(
                 if run_info:
                     from cooperbench.eval.evaluate import _evaluate_single
 
-                    eval_result = _evaluate_single(run_info, force=force)
+                    eval_result = _evaluate_single(run_info, force=force, backend=backend)
                     if eval_result:
                         stats = _process_eval_result(eval_result, tasks[0])
                         if stats:
@@ -171,7 +171,7 @@ def run(
     else:
         # Multiple tasks - show progress
         completed, skipped, failed, total_cost, results_list, eval_stats = _run_with_progress(
-            tasks, execute_task, concurrency, auto_eval, eval_concurrency, setting, run_name, force
+            tasks, execute_task, concurrency, auto_eval, eval_concurrency, setting, run_name, force, backend
         )
 
     # Summary
@@ -335,6 +335,7 @@ def _run_with_progress(
     setting: str,
     run_name: str,
     force: bool,
+    backend: str = "docker",
 ) -> tuple:
     """Run multiple tasks with progress display and optional inline evaluation."""
     from cooperbench.eval.evaluate import _evaluate_single
@@ -408,7 +409,7 @@ def _run_with_progress(
                         if auto_eval and status in ("done", "skip") and eval_executor:
                             run_info = _build_run_info(result, task_info, setting, run_name)
                             if run_info:
-                                eval_future = eval_executor.submit(_evaluate_single, run_info, force)
+                                eval_future = eval_executor.submit(_evaluate_single, run_info, force, backend)
                                 eval_futures[eval_future] = (task_info, result, task_name, feat_str)
                             progress.console.print(f"{status_display} {task_name} [dim][{feat_str}][/dim]")
                         else:

--- a/src/cooperbench/runner/solo.py
+++ b/src/cooperbench/runner/solo.py
@@ -20,7 +20,7 @@ def execute_solo(
     model_name: str = "vertex_ai/gemini-3-flash-preview",
     force: bool = False,
     quiet: bool = False,
-    backend: str = "modal",
+    backend: str = "docker",
     agent_config: str | None = None,
 ) -> dict | None:
     """Execute a solo task (one agent, multiple features).
@@ -144,7 +144,7 @@ def _spawn_solo_agent(
     agent_name: str,
     model_name: str,
     quiet: bool = False,
-    backend: str = "modal",
+    backend: str = "docker",
     agent_config: str | None = None,
     run_name: str | None = None,
 ) -> dict:


### PR DESCRIPTION
## Summary

- **Docker is now the default backend** everywhere (`cooperbench run`, `cooperbench eval`, and all helper APIs). Previously defaulted to `modal`, which required users to have a Modal account to run the benchmark.
- **Fixed a latent bug** where `cooperbench run --backend <X>` would silently fall back to modal during the inline auto-eval phase — the value was never forwarded to `_evaluate_single`.

## Changes

- `cli.py` — `run` and `eval` subcommand `--backend` defaults: `modal` → `docker`
- `eval/evaluate.py`, `eval/sandbox.py`, `eval/backends/__init__.py` — function-arg defaults: `modal` → `docker`
- `runner/core.py` — thread `backend` through single-task (`_evaluate_single(..., backend=backend)`) and multi-task (`_run_with_progress(..., backend)`) auto-eval call sites
- `runner/coop.py`, `runner/solo.py` — helper backend defaults: `modal` → `docker`
- `agents/mini_swe_agent{,_v2}/adapter.py` — config fallback: `modal` → `docker`
- `agents/mini_swe_agent{,_v2}/environments/__init__.py` — `get_environment` name default: `modal` → `docker`
- Bump `__about__.py` 0.0.6 → 0.0.7; CHANGELOG entry

## Test plan

- [ ] `cooperbench run -n smoke -r llama_index_task -t 17244 -f 1,2 -m openai/gpt-4o --setting solo` with no `--backend` flag runs agent *and* auto-eval under docker
- [ ] `cooperbench run --backend docker` behaves the same (no silent modal fallback in eval phase)
- [ ] Existing `--backend modal` users still work (no behavior change when backend is explicit)