### PR TITLE
agents: add Claude Code adapter with coop messaging + git collaboration

### DIFF
--- a/src/cooperbench/agents/__init__.py
+++ b/src/cooperbench/agents/__init__.py
@@ -106,6 +106,7 @@ AGENT_SHORTHANDS = {
     "mini_swe_agent_v2": "msa_v2",
     "swe_agent": "sw",
     "openhands_sdk": "oh",
+    "claude_code": "cc",
 }
 
 

--- a/src/cooperbench/agents/claude_code/__init__.py
+++ b/src/cooperbench/agents/claude_code/__init__.py
@@ -1,0 +1,1 @@
+"""Claude Code adapter for CooperBench."""

--- a/src/cooperbench/agents/claude_code/adapter.py
+++ b/src/cooperbench/agents/claude_code/adapter.py
@@ -1,0 +1,436 @@
+"""Claude Code adapter for CooperBench.
+
+Runs the official ``@anthropic-ai/claude-code`` CLI inside the task's
+Docker image and harvests the agent's diff from ``/workspace/repo/patch.txt``.
+
+The design mirrors Harbor's adapter (install in container, invoke in
+headless ``--print --output-format=stream-json`` mode, parse the final
+``result`` event for cost/tokens, walk the session JSONL for messages)
+but reuses CooperBench's existing ``DockerEnvironment`` from
+``mini_swe_agent_v2`` so the container lifecycle, image pulling, and
+``execute()`` semantics are consistent with the other adapters.
+
+Coop support: when ``agents`` has 2+ entries and ``comm_url`` is set,
+the adapter copies ``coop_msg.py`` into the container and exposes
+``coop-send``/``coop-recv``/``coop-broadcast``/``coop-peek``/``coop-agents``
+as shell commands.  Claude Code learns about them from the coop variant
+of the prompt template.  Inter-agent messages are still routed through
+the host Redis instance — we rewrite ``localhost`` to
+``host.docker.internal`` (and pass ``--add-host=host.docker.internal:host-gateway``)
+so the container can reach the host daemon on Linux.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import shlex
+from pathlib import Path
+from typing import Any, Protocol
+
+from cooperbench.agents import AgentResult
+from cooperbench.agents.claude_code.parsers import parse_session_jsonl, parse_stream_json
+from cooperbench.agents.claude_code.prompt import build_instruction
+from cooperbench.agents.registry import register
+
+logger = logging.getLogger(__name__)
+
+
+_PACKAGE_DIR = Path(__file__).parent
+SETUP_SCRIPT_PATH = _PACKAGE_DIR / "setup.sh"
+COOP_MSG_SCRIPT_PATH = _PACKAGE_DIR / "coop_msg.py"
+
+# Inside the container, we redirect Claude Code's per-session state under
+# /tmp so we always know where to find the JSONL trajectory after the run.
+CONTAINER_CLAUDE_CONFIG_DIR = "/tmp/claude-cfg"
+CONTAINER_STREAM_LOG = "/tmp/claude-stream.jsonl"
+CONTAINER_SETUP_PATH = "/tmp/claude-setup.sh"
+CONTAINER_INSTRUCTION_PATH = "/tmp/claude-instruction.txt"
+CONTAINER_COOP_MSG_PATH = "/tmp/claude-coop-msg.py"
+CONTAINER_COOP_SEND_LOG = "/tmp/claude-coop-sent.jsonl"
+CONTAINER_REPO_PATH = "/workspace/repo"
+
+DEFAULT_CREDENTIALS_PATH = Path.home() / ".claude" / ".credentials.json"
+
+
+def resolve_credentials(*, credentials_path: Path | None = None) -> dict[str, str]:
+    """Pick the credential to forward to the in-container Claude Code CLI.
+
+    Resolution order:
+
+    1. ``ANTHROPIC_API_KEY`` in the host environment (API-credit billing).
+    2. ``CLAUDE_CODE_OAUTH_TOKEN`` in the host environment (subscription).
+    3. ``claudeAiOauth.accessToken`` from ``~/.claude/.credentials.json``,
+       i.e. a host that's already logged in via ``claude login``.
+
+    Returns the chosen credential as a one-key dict ready to merge into
+    the container env; an empty dict means no credential was available
+    and the run will likely fail to authenticate.
+    """
+    api_key = os.environ.get("ANTHROPIC_API_KEY", "").strip()
+    if api_key:
+        return {"ANTHROPIC_API_KEY": api_key}
+
+    oauth = os.environ.get("CLAUDE_CODE_OAUTH_TOKEN", "").strip()
+    if oauth:
+        return {"CLAUDE_CODE_OAUTH_TOKEN": oauth}
+
+    path = credentials_path if credentials_path is not None else DEFAULT_CREDENTIALS_PATH
+    try:
+        data = json.loads(path.read_text())
+    except (OSError, json.JSONDecodeError):
+        return {}
+    token = (data.get("claudeAiOauth") or {}).get("accessToken")
+    if isinstance(token, str) and token.strip():
+        return {"CLAUDE_CODE_OAUTH_TOKEN": token.strip()}
+    return {}
+
+
+def rewrite_comm_url_for_container(url: str | None) -> str | None:
+    """Make a host-side Redis URL reachable from inside the agent container.
+
+    ``localhost`` and ``127.0.0.1`` point at the container itself, not
+    the host where the coop runner started Redis.  Substitute
+    ``host.docker.internal``, which resolves to the host gateway when
+    the container is started with ``--add-host=host.docker.internal:host-gateway``
+    (Linux) or natively on Docker Desktop (macOS/Windows).
+    """
+    if not url:
+        return url
+    # Use string substitution rather than urlparse to preserve the
+    # ``#run:<id>`` fragment that the MessagingConnector relies on.
+    for needle in ("//localhost", "//127.0.0.1"):
+        if needle in url:
+            return url.replace(needle, "//host.docker.internal", 1)
+    return url
+
+
+def build_git_setup_command(*, agent_id: str, server_url: str) -> str:
+    """Shell snippet that configures the in-container repo as a participant
+    in the shared git remote.
+
+    Mirrors mini_swe_agent_v2's ``GitConnector.setup`` but emitted as a
+    single ``bash -lc``-friendly string so it can be exec'd through the
+    same ``env.execute`` channel as everything else.  Idempotent: re-running
+    is safe (set-url replaces remote if it already exists; branch checkout
+    falls back to checkout if it already exists).
+    """
+    server = shlex.quote(server_url)
+    aid = shlex.quote(agent_id)
+    branch = shlex.quote(agent_id)
+    return (
+        f"cd {shlex.quote(CONTAINER_REPO_PATH)} && "
+        f"git config user.email 'agent@cooperbench.local' && "
+        f"git config user.name {aid} && "
+        f"(git remote add team {server} 2>/dev/null || git remote set-url team {server}) && "
+        f"(git checkout -b {branch} 2>/dev/null || git checkout {branch}) && "
+        f"git push -u team {branch} --force && "
+        "git push team HEAD:refs/heads/main --force 2>/dev/null || true"
+    )
+
+
+def parse_sent_messages_log(text: str) -> list[dict[str, Any]]:
+    """Parse the in-container coop send-log into a list of message dicts."""
+    out: list[dict[str, Any]] = []
+    for line in text.splitlines():
+        line = line.strip()
+        if not line or not line.startswith("{"):
+            continue
+        try:
+            out.append(json.loads(line))
+        except json.JSONDecodeError:
+            continue
+    return out
+
+
+class _Env(Protocol):
+    """Minimal interface we need from the environment.
+
+    Defined as a Protocol (not imported from mini_swe_agent_v2) so unit
+    tests can stub in a tiny fake without instantiating Docker.
+    """
+
+    def execute(self, action: dict, cwd: str = "", *, timeout: int | None = None) -> dict[str, Any]: ...
+    def cleanup(self) -> None: ...
+
+
+def _build_environment(
+    image: str,
+    *,
+    network: str | None = None,
+    extra_run_args: list[str] | None = None,
+    timeout: int = 7200,
+) -> _Env:
+    """Spin up a long-lived Docker container for the run.
+
+    Factored out so tests can monkey-patch this to inject a fake env.
+    ``extra_run_args`` are appended to ``docker run`` (e.g. host-gateway
+    mapping for coop).
+    """
+    from cooperbench.agents.mini_swe_agent_v2.environments.docker import DockerEnvironment
+
+    run_args = ["--rm"]
+    if extra_run_args:
+        run_args.extend(extra_run_args)
+
+    kwargs: dict[str, Any] = {
+        "image": image,
+        "cwd": CONTAINER_REPO_PATH,
+        "timeout": timeout,
+        "run_args": run_args,
+    }
+    if network:
+        kwargs["network"] = network
+    return DockerEnvironment(**kwargs)
+
+
+def _strip_provider_prefix(model_name: str) -> str:
+    """``anthropic/claude-sonnet-4-6`` -> ``claude-sonnet-4-6``.
+
+    Claude Code's ``ANTHROPIC_MODEL`` env var wants the bare model id when
+    talking to the official Anthropic API.  Other providers' prefixes are
+    not supported by Claude Code itself, so stripping the leading
+    ``provider/`` is the only sane default.
+    """
+    if "/" in model_name:
+        return model_name.split("/", 1)[1]
+    return model_name
+
+
+def _build_claude_command(
+    instruction_path: str,
+    model_name: str,
+    stream_log_path: str,
+    *,
+    extra_flags: str = "",
+    coop_env: dict[str, str] | None = None,
+) -> str:
+    """Compose the in-container shell command that invokes Claude Code.
+
+    We read the prompt from a file (rather than inlining via ``-p``) so
+    long instructions don't blow past argv limits and don't need
+    shell-escaping.
+    """
+    model = _strip_provider_prefix(model_name)
+    coop_exports = ""
+    if coop_env:
+        coop_exports = "".join(f"export {k}={shlex.quote(v)}; " for k, v in coop_env.items())
+    # The PATH manipulation is needed when claude-code is installed under
+    # ``~/.local/bin`` (curl-based install path); npm-installed binaries
+    # land in /usr/bin so this is a no-op there.
+    return (
+        'export PATH="$HOME/.local/bin:$PATH"; '
+        f"export ANTHROPIC_MODEL={shlex.quote(model)}; "
+        f"export CLAUDE_CONFIG_DIR={shlex.quote(CONTAINER_CLAUDE_CONFIG_DIR)}; "
+        "export IS_SANDBOX=1; "
+        "export FORCE_AUTO_BACKGROUND_TASKS=1; "
+        "export ENABLE_BACKGROUND_TASKS=1; "
+        "export CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC=1; "
+        + coop_exports
+        + f"mkdir -p {CONTAINER_CLAUDE_CONFIG_DIR}; "
+        f"cd {CONTAINER_REPO_PATH} && "
+        "claude --verbose --output-format=stream-json "
+        "--permission-mode=bypassPermissions "
+        f"{extra_flags}"
+        f'--print -- "$(cat {shlex.quote(instruction_path)})" '
+        f"2>&1 | tee {shlex.quote(stream_log_path)}"
+    )
+
+
+def _write_file_in_container(env: _Env, path: str, content: str) -> dict[str, Any]:
+    """Write a file inside the container via a heredoc.
+
+    Using a sentinel that's unlikely to appear in either instruction text
+    or shell scripts.
+    """
+    sentinel = "COOPERBENCH_HEREDOC_EOF_5e7b"
+    cmd = f"cat > {shlex.quote(path)} <<'{sentinel}'\n{content}\n{sentinel}\n"
+    return env.execute({"command": cmd})
+
+
+def _read_file_from_container(env: _Env, path: str) -> str:
+    result = env.execute({"command": f"cat {shlex.quote(path)} 2>/dev/null"})
+    if result.get("returncode") == 0:
+        return result.get("output") or ""
+    return ""
+
+
+def _find_session_jsonl(env: _Env) -> str:
+    """Concatenate every session ``*.jsonl`` produced under CLAUDE_CONFIG_DIR.
+
+    Claude Code writes one file per session; there will normally be
+    exactly one for a fresh container.
+    """
+    cmd = f"find {CONTAINER_CLAUDE_CONFIG_DIR}/projects -name '*.jsonl' -type f 2>/dev/null | xargs -r cat"
+    result = env.execute({"command": cmd})
+    if result.get("returncode") == 0:
+        return result.get("output") or ""
+    return ""
+
+
+@register("claude_code")
+class ClaudeCodeRunner:
+    """Adapter for the official Claude Code CLI.
+
+    Supports solo and coop runs.  Git collaboration (push/pull/merge via
+    a shared remote) is not yet wired — the adapter joins the shared
+    docker network if ``git_network`` is set in ``config`` so a follow-up
+    can layer on top.
+    """
+
+    def run(
+        self,
+        task: str,
+        image: str,
+        *,
+        agent_id: str = "agent",
+        model_name: str = "claude-sonnet-4-6",
+        agents: list[str] | None = None,
+        comm_url: str | None = None,
+        git_server_url: str | None = None,
+        git_enabled: bool = False,
+        messaging_enabled: bool = True,
+        config: dict | None = None,
+        agent_config: str | None = None,
+        log_dir: str | None = None,
+        **kwargs: Any,
+    ) -> AgentResult:
+        del agent_config, kwargs  # external-agent-config not yet wired
+        config = config or {}
+
+        credentials = resolve_credentials()
+        if not credentials:
+            logger.warning(
+                "No Claude Code credentials found (checked ANTHROPIC_API_KEY, "
+                "CLAUDE_CODE_OAUTH_TOKEN, and ~/.claude/.credentials.json). "
+                "The in-container CLI will fail to authenticate."
+            )
+
+        is_coop = bool(messaging_enabled and comm_url and agents and len(agents) > 1)
+        use_git = bool(git_enabled and git_server_url and agents and len(agents) > 1)
+        instruction = build_instruction(
+            task,
+            agents=agents if is_coop else None,
+            agent_id=agent_id if is_coop else None,
+            git_enabled=use_git,
+        )
+        setup_script = SETUP_SCRIPT_PATH.read_text()
+        coop_msg_source = COOP_MSG_SCRIPT_PATH.read_text() if is_coop else None
+
+        coop_env: dict[str, str] = {}
+        extra_run_args: list[str] = []
+        if is_coop:
+            container_url = rewrite_comm_url_for_container(comm_url) or ""
+            coop_env = {
+                "COOP_REDIS_URL": container_url,
+                "COOP_AGENT_ID": agent_id,
+                "COOP_AGENTS": ",".join(agents or []),
+                "COOP_LOG_PATH": CONTAINER_COOP_SEND_LOG,
+            }
+            extra_run_args.append("--add-host=host.docker.internal:host-gateway")
+
+        max_turns = config.get("max_turns")
+        extra_flags = ""
+        if max_turns:
+            extra_flags = f"--max-turns {int(max_turns)} "
+
+        network = config.get("git_network") if isinstance(config, dict) else None
+        env = _build_environment(image, network=network, extra_run_args=extra_run_args or None)
+
+        status = "Error"
+        error_msg: str | None = None
+        stream_text = ""
+        session_text = ""
+        patch_text = ""
+        sent_log_text = ""
+
+        try:
+            # 1. Drop the coop helper (if needed) BEFORE running setup.sh
+            #    so setup can symlink the coop-* wrappers under /usr/local/bin.
+            if coop_msg_source is not None:
+                _write_file_in_container(env, CONTAINER_COOP_MSG_PATH, coop_msg_source)
+
+            # 2. Install claude-code in the container.
+            _write_file_in_container(env, CONTAINER_SETUP_PATH, setup_script)
+            install = env.execute(
+                {"command": f"bash {shlex.quote(CONTAINER_SETUP_PATH)}"},
+                timeout=600,
+            )
+            if install.get("returncode") not in (0, None):
+                raise RuntimeError("claude-code install failed: " + (install.get("output") or "")[:2000])
+
+            # 3a. Optional: configure the shared git remote so peers can
+            #     fetch each other's branches.
+            if use_git:
+                git_cmd = build_git_setup_command(
+                    agent_id=agent_id,
+                    server_url=git_server_url or "",
+                )
+                git_setup = env.execute({"command": git_cmd}, timeout=120)
+                if git_setup.get("returncode") not in (0, None):
+                    logger.warning(
+                        "git setup returned non-zero: %s",
+                        (git_setup.get("output") or "")[:500],
+                    )
+
+            # 3. Write the instruction to a file and invoke claude.
+            _write_file_in_container(env, CONTAINER_INSTRUCTION_PATH, instruction)
+            cred_exports = "".join(f"export {k}={shlex.quote(v)}; " for k, v in credentials.items())
+            invoke_cmd = cred_exports + _build_claude_command(
+                CONTAINER_INSTRUCTION_PATH,
+                model_name,
+                CONTAINER_STREAM_LOG,
+                extra_flags=extra_flags,
+                coop_env=coop_env or None,
+            )
+            env.execute({"command": invoke_cmd}, timeout=7200)
+
+            # 4. Collect outputs.
+            stream_text = _read_file_from_container(env, CONTAINER_STREAM_LOG)
+            session_text = _find_session_jsonl(env)
+            patch_text = _read_file_from_container(env, f"{CONTAINER_REPO_PATH}/patch.txt").strip()
+            if is_coop:
+                sent_log_text = _read_file_from_container(env, CONTAINER_COOP_SEND_LOG)
+        except Exception as e:
+            error_msg = str(e)
+            logger.exception("Claude Code adapter run failed")
+        finally:
+            try:
+                env.cleanup()
+            except Exception:
+                logger.warning("Env cleanup failed", exc_info=True)
+
+        summary = parse_stream_json(stream_text)
+        messages = parse_session_jsonl(session_text)
+        sent_messages = parse_sent_messages_log(sent_log_text)
+
+        if error_msg is not None:
+            status = "Error"
+        else:
+            status = summary.status
+
+        if log_dir:
+            try:
+                log_root = Path(log_dir)
+                log_root.mkdir(parents=True, exist_ok=True)
+                (log_root / f"{agent_id}_stream.jsonl").write_text(stream_text)
+                (log_root / f"{agent_id}_session.jsonl").write_text(session_text)
+                if sent_log_text:
+                    (log_root / f"{agent_id}_sent.jsonl").write_text(sent_log_text)
+            except OSError:
+                logger.warning("Failed to persist Claude Code logs", exc_info=True)
+
+        return AgentResult(
+            status=status,
+            patch=patch_text,
+            cost=summary.cost,
+            steps=summary.steps,
+            input_tokens=summary.input_tokens,
+            output_tokens=summary.output_tokens,
+            cache_read_tokens=summary.cache_read_tokens,
+            cache_write_tokens=summary.cache_write_tokens,
+            messages=messages,
+            sent_messages=sent_messages,
+            error=error_msg,
+        )

--- a/src/cooperbench/agents/claude_code/coop_msg.py
+++ b/src/cooperbench/agents/claude_code/coop_msg.py
@@ -1,0 +1,150 @@
+#!/usr/bin/env python3
+"""Tiny messaging CLI for Claude Code to use inside the agent container.
+
+Mirrors the semantics of CooperBench's host-side ``MessagingConnector``
+(Redis lists, one inbox per agent, optional ``#run:<id>`` namespace
+prefix) but lives in the container so the in-process LLM can invoke it
+via Bash.
+
+Usage:
+    coop-send <recipient> <content>      # send to one agent
+    coop-broadcast <content>             # send to every other agent
+    coop-recv                            # drain this agent's inbox (JSON list)
+    coop-peek                            # count unread messages
+    coop-agents                          # list all agent ids
+
+Config is read from environment variables (set by the adapter):
+    COOP_REDIS_URL   redis://host[:port][/db][#run:<id>]
+    COOP_AGENT_ID    this agent's id (e.g. "agent1")
+    COOP_AGENTS      comma-separated list (e.g. "agent1,agent2")
+    COOP_LOG_PATH    optional; if set, every successful send is appended
+                     to this file as one JSON line for the host adapter
+                     to harvest after the run.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+import time
+from datetime import datetime
+from typing import Any
+
+import redis
+
+
+def _client_and_prefix() -> tuple[redis.Redis, str]:
+    url = os.environ["COOP_REDIS_URL"]
+    if "#" in url:
+        url, prefix = url.split("#", 1)
+        prefix = prefix + ":"
+    else:
+        prefix = ""
+    return redis.from_url(url), prefix
+
+
+def _agent_id() -> str:
+    return os.environ["COOP_AGENT_ID"]
+
+
+def _agents() -> list[str]:
+    raw = os.environ.get("COOP_AGENTS", "")
+    return [a.strip() for a in raw.split(",") if a.strip()]
+
+
+def _log_send(entry: dict[str, Any]) -> None:
+    path = os.environ.get("COOP_LOG_PATH")
+    if not path:
+        return
+    try:
+        with open(path, "a") as fh:
+            fh.write(json.dumps(entry) + "\n")
+    except OSError:
+        # Logging failure shouldn't interrupt the send.
+        pass
+
+
+def _send(client: redis.Redis, prefix: str, recipient: str, content: str) -> None:
+    entry = {
+        "from": _agent_id(),
+        "to": recipient,
+        "content": content,
+        "timestamp": time.time(),
+        "timestamp_iso": datetime.now().isoformat(),
+    }
+    client.rpush(f"{prefix}{recipient}:inbox", json.dumps(entry))
+    _log_send(entry)
+
+
+def cmd_send(args: argparse.Namespace) -> int:
+    client, prefix = _client_and_prefix()
+    content = args.content if args.content is not None else sys.stdin.read()
+    _send(client, prefix, args.recipient, content)
+    print(f"sent to {args.recipient}", file=sys.stderr)
+    return 0
+
+
+def cmd_broadcast(args: argparse.Namespace) -> int:
+    client, prefix = _client_and_prefix()
+    content = args.content if args.content is not None else sys.stdin.read()
+    me = _agent_id()
+    for agent in _agents():
+        if agent == me:
+            continue
+        _send(client, prefix, agent, content)
+    return 0
+
+
+def cmd_recv(_args: argparse.Namespace) -> int:
+    client, prefix = _client_and_prefix()
+    key = f"{prefix}{_agent_id()}:inbox"
+    messages = []
+    while True:
+        raw = client.lpop(key)
+        if raw is None:
+            break
+        try:
+            messages.append(json.loads(raw))
+        except json.JSONDecodeError:
+            messages.append({"content": raw.decode() if isinstance(raw, bytes) else raw})
+    print(json.dumps(messages, indent=2))
+    return 0
+
+
+def cmd_peek(_args: argparse.Namespace) -> int:
+    client, prefix = _client_and_prefix()
+    print(client.llen(f"{prefix}{_agent_id()}:inbox"))
+    return 0
+
+
+def cmd_agents(_args: argparse.Namespace) -> int:
+    for agent in _agents():
+        print(agent)
+    return 0
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(prog="coop-msg")
+    sub = parser.add_subparsers(dest="cmd", required=True)
+
+    p_send = sub.add_parser("send")
+    p_send.add_argument("recipient")
+    p_send.add_argument("content", nargs="?", default=None)
+    p_send.set_defaults(func=cmd_send)
+
+    p_bcast = sub.add_parser("broadcast")
+    p_bcast.add_argument("content", nargs="?", default=None)
+    p_bcast.set_defaults(func=cmd_broadcast)
+
+    sub.add_parser("recv").set_defaults(func=cmd_recv)
+    sub.add_parser("peek").set_defaults(func=cmd_peek)
+    sub.add_parser("agents").set_defaults(func=cmd_agents)
+
+    args = parser.parse_args(argv)
+    return args.func(args)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/cooperbench/agents/claude_code/parsers.py
+++ b/src/cooperbench/agents/claude_code/parsers.py
@@ -1,0 +1,153 @@
+"""Pure parsers for Claude Code's stream-json and session-JSONL output.
+
+Kept independent of any container/CLI machinery so they can be unit-tested
+against fixture strings.
+
+Stream-json shape (one JSON object per line) is documented at
+https://docs.anthropic.com/en/docs/agents/claude-code. The terminating
+event is ``{"type": "result", ...}`` and is the source of truth for cost
+and turn count. Session JSONL lives under
+``$CLAUDE_CONFIG_DIR/projects/<slug>/<session-id>/*.jsonl`` and contains
+the raw assistant/user/tool turns.
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass, field
+from typing import Any
+
+
+@dataclass
+class StreamSummary:
+    """Aggregate stats extracted from the final ``result`` event."""
+
+    status: str = "Error"
+    cost: float = 0.0
+    steps: int = 0
+    input_tokens: int = 0
+    output_tokens: int = 0
+    cache_read_tokens: int = 0
+    cache_write_tokens: int = 0
+    raw_result: dict[str, Any] = field(default_factory=dict)
+
+
+def _iter_json_lines(text: str):
+    for line in text.splitlines():
+        line = line.strip()
+        if not line or not line.startswith("{"):
+            continue
+        try:
+            yield json.loads(line)
+        except json.JSONDecodeError:
+            continue
+
+
+def parse_stream_json(text: str) -> StreamSummary:
+    """Extract cost/tokens/status from ``claude --output-format=stream-json`` output.
+
+    The final ``{"type": "result", ...}`` event is authoritative.  If it's
+    missing (CLI crashed, killed by timeout), status is ``"Error"`` and
+    counters are zero.
+    """
+    for event in _iter_json_lines(text):
+        if event.get("type") != "result":
+            continue
+        usage = event.get("usage") or {}
+        is_error = bool(event.get("is_error")) or event.get("subtype", "success") != "success"
+        status = "Submitted"
+        if is_error:
+            subtype = event.get("subtype", "")
+            if "max_turns" in subtype or "limit" in subtype or "budget" in subtype:
+                status = "LimitsExceeded"
+            else:
+                status = "Error"
+        return StreamSummary(
+            status=status,
+            cost=float(event.get("total_cost_usd") or 0.0),
+            steps=int(event.get("num_turns") or 0),
+            input_tokens=int(usage.get("input_tokens") or 0),
+            output_tokens=int(usage.get("output_tokens") or 0),
+            cache_read_tokens=int(usage.get("cache_read_input_tokens") or 0),
+            cache_write_tokens=int(usage.get("cache_creation_input_tokens") or 0),
+            raw_result=event,
+        )
+    return StreamSummary()
+
+
+def _content_blocks_to_text(content: Any) -> str:
+    """Flatten a Claude message ``content`` field to a plain string.
+
+    Anthropic messages use a list of typed blocks (text/tool_use/
+    tool_result/thinking).  Downstream CooperBench code does
+    ``"send_message" in msg["content"]`` so we must always return a string.
+    """
+    if content is None:
+        return ""
+    if isinstance(content, str):
+        return content
+    if not isinstance(content, list):
+        try:
+            return json.dumps(content, ensure_ascii=False)
+        except TypeError:
+            return str(content)
+
+    parts: list[str] = []
+    for block in content:
+        if not isinstance(block, dict):
+            parts.append(str(block))
+            continue
+        btype = block.get("type")
+        if btype == "text":
+            text = block.get("text", "")
+            if text:
+                parts.append(text)
+        elif btype == "thinking":
+            thought = block.get("thinking") or block.get("text") or ""
+            if thought:
+                parts.append(f"[thinking] {thought}")
+        elif btype == "tool_use":
+            name = block.get("name", "")
+            args = block.get("input")
+            try:
+                args_str = json.dumps(args, ensure_ascii=False)
+            except TypeError:
+                args_str = str(args)
+            parts.append(f"[tool_use {name}] {args_str}")
+        elif btype == "tool_result":
+            inner = block.get("content")
+            if isinstance(inner, list):
+                inner_text = "\n".join(b.get("text", "") if isinstance(b, dict) else str(b) for b in inner)
+            elif inner is None:
+                inner_text = ""
+            else:
+                inner_text = str(inner)
+            parts.append(f"[tool_result] {inner_text}")
+        else:
+            try:
+                parts.append(json.dumps(block, ensure_ascii=False))
+            except TypeError:
+                parts.append(str(block))
+    return "\n".join(p for p in parts if p)
+
+
+def parse_session_jsonl(text: str) -> list[dict[str, str]]:
+    """Convert Claude Code session JSONL to OpenAI-style chat messages.
+
+    Returns a list of ``{"role": ..., "content": ...}`` dicts, sorted by
+    ``timestamp``.  ``content`` is always a string.
+    """
+    events: list[dict[str, Any]] = list(_iter_json_lines(text))
+    events.sort(key=lambda e: e.get("timestamp") or "")
+
+    messages: list[dict[str, str]] = []
+    for event in events:
+        message = event.get("message")
+        if not isinstance(message, dict):
+            continue
+        role = message.get("role")
+        if role not in {"user", "assistant", "system"}:
+            continue
+        content_text = _content_blocks_to_text(message.get("content"))
+        messages.append({"role": role, "content": content_text})
+    return messages

--- a/src/cooperbench/agents/claude_code/prompt.py
+++ b/src/cooperbench/agents/claude_code/prompt.py
@@ -1,0 +1,140 @@
+"""Instruction templates for solo and coop modes.
+
+Claude Code doesn't speak the ``COMPLETE_TASK_AND_SUBMIT_FINAL_OUTPUT``
+sentinel that mini-swe-agent v2 uses — it just exits when it considers
+the work done.  All we need is for the agent to write its unified diff
+to ``patch.txt`` in the repo before exiting; the adapter reads the file
+post-run.  In coop mode we additionally document the coop-* messaging
+helpers so the agent can coordinate with its peers.
+"""
+
+from __future__ import annotations
+
+_SUBMISSION_BLOCK = """## Submission protocol
+
+When you are done editing the codebase, write your final unified diff to
+`/workspace/repo/patch.txt` BEFORE exiting.  The bench evaluator reads
+that file; nothing else is inspected.  A typical pattern:
+
+```bash
+cd /workspace/repo
+git diff > patch.txt
+cat patch.txt   # sanity-check that the diff is what you intend to submit
+```
+
+Constraints on `patch.txt`:
+
+- Must be a unified diff (`git diff` output is fine).
+- Should contain ONLY source files you intentionally modified to implement
+  the feature.  Exclude reproduction scripts, scratch tests, or
+  helper files you wrote during development.
+- Do not include changes to test files unless the task explicitly asks
+  you to modify tests.
+
+You are free to read files, run shell commands, and run tests as needed."""
+
+
+def _git_block(agent_id: str, partners: list[str]) -> str:
+    partner_branches = ", ".join(f"`team/{p}`" for p in partners)
+    first_partner = partners[0]
+    return f"""## Git collaboration
+
+A shared git remote named `team` is already configured in this repo.
+Use it to share code with your peers — messages alone aren't enough
+when you both touch the same files.
+
+- Your branch: `{agent_id}` (already created and pushed)
+- Partner branches: {partner_branches}
+- Base reference: `team/main` (pristine starting state)
+
+Recommended workflow:
+
+```bash
+# See what your peers have published:
+git fetch team
+git branch -r
+git log team/{first_partner} --oneline -10
+
+# Inspect a peer's change without merging:
+git show team/{first_partner} -- path/to/file
+
+# Pull a peer's work into your tree.  Resolve any merge conflicts in
+# the working tree, then commit.  If the merge is clean, --no-edit
+# takes the default commit message and you're done.
+git fetch team && git merge --no-edit team/{first_partner}
+
+# Publish your own progress (after committing locally):
+git add -A
+git commit -m 'wip: <one-line summary>'
+git push team {agent_id}
+```
+
+Concretely: before submitting, run `git fetch team` and look at every
+peer branch.  If one of them edited a file you also edited, merge
+their branch into yours and rebuild `patch.txt` from the merged tree
+(`git diff team/main..HEAD > patch.txt`) so your submission contains
+both your work and theirs."""
+
+
+def _coop_block(agent_id: str, partners: list[str]) -> str:
+    partner_str = ", ".join(partners)
+    return f"""## Cooperation protocol
+
+You are **{agent_id}**, working alongside: **{partner_str}**.
+Each agent has been assigned a separate feature from the same codebase;
+your features may overlap (touch the same files), so coordinate to avoid
+clobbering each other's changes.
+
+Available shell commands for cross-agent messaging (Redis-backed inbox,
+one inbox per agent):
+
+```bash
+coop-send <recipient> "message text here"   # send to a specific peer
+coop-broadcast "message text here"          # send to every other peer
+coop-recv                                    # drain your inbox (prints JSON list)
+coop-peek                                    # number of unread messages
+coop-agents                                  # list every agent id
+```
+
+Recommended workflow:
+
+1. At the start, `coop-broadcast` a short summary of your feature and
+   which files you intend to touch.
+2. Periodically `coop-recv` to read what your peers have sent — at
+   minimum after major edits and before submitting.
+3. If two agents need to modify the same file, coordinate explicitly
+   (split the file, agree on one owner, or merge changes).
+4. Keep messages short and focused: file names, function names, and
+   one-sentence intents are usually enough.
+
+Messages are not magic — your peers only know what you tell them.
+"""
+
+
+def build_instruction(
+    task: str,
+    *,
+    agents: list[str] | None = None,
+    agent_id: str | None = None,
+    git_enabled: bool = False,
+) -> str:
+    """Compose the full instruction for a single agent run.
+
+    Args:
+        task: The raw feature spec (the user-facing task description).
+        agents: All agent ids in the run.  When this has 2+ entries we
+            emit the coop messaging block.
+        agent_id: This agent's id.  Required when ``agents`` is multi.
+        git_enabled: Whether the shared git remote is configured.  When
+            true (and we're in coop mode), append a git collaboration
+            section to the prompt.
+    """
+    partners: list[str] = []
+    if agents and agent_id:
+        partners = [a for a in agents if a != agent_id]
+    sections = [task, _SUBMISSION_BLOCK]
+    if partners and agent_id:
+        sections.append(_coop_block(agent_id, partners))
+        if git_enabled:
+            sections.append(_git_block(agent_id, partners))
+    return "\n\n---\n\n".join(sections)

--- a/src/cooperbench/agents/claude_code/setup.sh
+++ b/src/cooperbench/agents/claude_code/setup.sh
@@ -1,0 +1,65 @@
+#!/bin/bash
+# Installs Claude Code into the task container.  Mirrors terminal-bench's
+# claude-code-setup.sh.j2 but as a static script (no template rendering).
+# Also installs the in-container coop messaging helper used in coop runs.
+set -e
+
+# Pick a package manager that exists.  Most CooperBench task images are
+# Debian-based python:3.11-slim, but we keep the alpine/yum fallbacks for
+# parity with Harbor's adapter so a wider range of base images work.
+if command -v apt-get >/dev/null 2>&1; then
+    apt-get update -qq
+    apt-get install -y --no-install-recommends curl ca-certificates gnupg >/dev/null
+elif command -v apk >/dev/null 2>&1; then
+    apk add --no-cache curl bash nodejs npm >/dev/null
+elif command -v yum >/dev/null 2>&1; then
+    yum install -y curl >/dev/null
+fi
+
+# Install Node.js (>=20 required by claude-code).  Use NodeSource so we
+# get a recent version on Debian.  Skip when npm is already present (alpine).
+if ! command -v npm >/dev/null 2>&1; then
+    curl -fsSL https://deb.nodesource.com/setup_22.x | bash - >/dev/null
+    apt-get install -y --no-install-recommends nodejs >/dev/null
+fi
+
+VERSION="${CLAUDE_CODE_VERSION:-latest}"
+npm install -g --silent "@anthropic-ai/claude-code@${VERSION}"
+
+claude --version
+
+# Coop messaging helper: only needed when COOP_REDIS_URL is set, but
+# install unconditionally so the container layout is identical.
+if command -v pip >/dev/null 2>&1; then
+    pip install --quiet --disable-pip-version-check redis >/dev/null || true
+elif command -v pip3 >/dev/null 2>&1; then
+    pip3 install --quiet --disable-pip-version-check redis >/dev/null || true
+fi
+
+# coop_msg.py is dropped at /tmp/claude-coop-msg.py by the adapter.
+# Symlink the subcommands so Claude can call them as standalone tools.
+if [ -f /tmp/claude-coop-msg.py ]; then
+    chmod +x /tmp/claude-coop-msg.py
+    cat >/usr/local/bin/coop-send <<'EOF'
+#!/bin/bash
+exec python3 /tmp/claude-coop-msg.py send "$@"
+EOF
+    cat >/usr/local/bin/coop-recv <<'EOF'
+#!/bin/bash
+exec python3 /tmp/claude-coop-msg.py recv "$@"
+EOF
+    cat >/usr/local/bin/coop-broadcast <<'EOF'
+#!/bin/bash
+exec python3 /tmp/claude-coop-msg.py broadcast "$@"
+EOF
+    cat >/usr/local/bin/coop-peek <<'EOF'
+#!/bin/bash
+exec python3 /tmp/claude-coop-msg.py peek "$@"
+EOF
+    cat >/usr/local/bin/coop-agents <<'EOF'
+#!/bin/bash
+exec python3 /tmp/claude-coop-msg.py agents "$@"
+EOF
+    chmod +x /usr/local/bin/coop-send /usr/local/bin/coop-recv \
+        /usr/local/bin/coop-broadcast /usr/local/bin/coop-peek /usr/local/bin/coop-agents
+fi

--- a/src/cooperbench/agents/registry.py
+++ b/src/cooperbench/agents/registry.py
@@ -78,6 +78,10 @@ def _auto_register():
         import cooperbench.agents.openhands_agent_sdk.adapter  # noqa: F401
     except ImportError:
         pass
+    try:
+        import cooperbench.agents.claude_code.adapter  # noqa: F401
+    except ImportError:
+        pass
 
     # External agents via environment variable
     import os

--- a/tests/agents/claude_code/test_adapter.py
+++ b/tests/agents/claude_code/test_adapter.py
@@ -1,0 +1,553 @@
+"""Tests for the Claude Code adapter.
+
+These tests stub out the Docker environment so they run fast and require
+no daemon. We assert that the adapter:
+
+  - is registered under ``"claude_code"``
+  - exposes the ``AgentRunner`` shape
+  - in ``run``, performs install + invoke + ``cat patch.txt`` calls in order
+  - returns an ``AgentResult`` populated from the parsed stream-json + session
+"""
+
+import json
+from unittest.mock import patch as mock_patch
+
+import pytest
+
+from cooperbench.agents import AgentResult, get_runner, list_agents
+from cooperbench.agents.claude_code.adapter import (
+    build_git_setup_command,
+    parse_sent_messages_log,
+    rewrite_comm_url_for_container,
+    resolve_credentials,
+)
+from cooperbench.agents.claude_code.prompt import build_instruction
+
+
+class _FakeEnv:
+    """Captures executed commands and returns scripted outputs.
+
+    Outputs are dispatched by the substring keys in ``responses``; the
+    first key found in the command is used.  Commands that don't match
+    any key (e.g. heredoc writes) return ``returncode=0`` with empty
+    stdout, which is what real shells do.
+    """
+
+    def __init__(self, responses):
+        self._responses = responses
+        self.executed: list[str] = []
+        self.cleaned = False
+        self.install_failed = False
+
+    def execute(self, action, cwd: str = "", *, timeout: int | None = None):
+        command = action.get("command", "")
+        self.executed.append(command)
+        for key, value in self._responses.items():
+            if key in command:
+                return value
+        return {"output": "", "returncode": 0}
+
+    def cleanup(self):
+        self.cleaned = True
+
+
+@pytest.fixture
+def fake_env_factory():
+    def _factory(responses):
+        return _FakeEnv(responses)
+
+    return _factory
+
+
+@pytest.fixture
+def stream_json_success():
+    return "\n".join(
+        [
+            json.dumps({"type": "system", "subtype": "init"}),
+            json.dumps(
+                {
+                    "type": "result",
+                    "subtype": "success",
+                    "total_cost_usd": 0.12,
+                    "num_turns": 5,
+                    "usage": {
+                        "input_tokens": 1000,
+                        "output_tokens": 200,
+                        "cache_read_input_tokens": 50,
+                        "cache_creation_input_tokens": 10,
+                    },
+                }
+            ),
+        ]
+    )
+
+
+@pytest.fixture
+def session_jsonl_one_turn():
+    return json.dumps(
+        {
+            "type": "user",
+            "message": {"role": "user", "content": "Hello"},
+            "timestamp": "2026-01-01T00:00:00Z",
+        }
+    )
+
+
+class TestRewriteCommUrl:
+    """The coop runner gives us a host-side Redis URL like
+    ``redis://localhost:6379#run:abc``.  ``localhost`` is unreachable
+    from inside a Docker container; rewrite it so the in-container
+    helper can reach Redis on the host.
+    """
+
+    def test_localhost_replaced_with_host_docker_internal(self):
+        assert (
+            rewrite_comm_url_for_container("redis://localhost:6379#run:abc")
+            == "redis://host.docker.internal:6379#run:abc"
+        )
+
+    def test_127001_replaced(self):
+        assert (
+            rewrite_comm_url_for_container("redis://127.0.0.1:6379")
+            == "redis://host.docker.internal:6379"
+        )
+
+    def test_external_host_preserved(self):
+        url = "redis://my-redis.example.com:6379#run:abc"
+        assert rewrite_comm_url_for_container(url) == url
+
+    def test_none_returns_none(self):
+        assert rewrite_comm_url_for_container(None) is None
+
+
+class TestParseSentMessagesLog:
+    """The in-container messaging helper appends one JSON object per send
+    to a log file. We harvest it post-run to populate
+    ``AgentResult.sent_messages``."""
+
+    def test_parses_one_send_per_line(self):
+        log = "\n".join(
+            [
+                json.dumps({"to": "agent2", "content": "starting on auth", "timestamp": 1.0}),
+                json.dumps({"to": "agent2", "content": "done", "timestamp": 2.0}),
+            ]
+        )
+        msgs = parse_sent_messages_log(log)
+        assert len(msgs) == 2
+        assert msgs[0]["to"] == "agent2"
+        assert msgs[0]["content"] == "starting on auth"
+
+    def test_skips_blank_and_invalid_lines(self):
+        log = "\n".join(
+            [
+                "",
+                "not json",
+                json.dumps({"to": "agent2", "content": "ok"}),
+            ]
+        )
+        msgs = parse_sent_messages_log(log)
+        assert msgs == [{"to": "agent2", "content": "ok"}]
+
+    def test_empty_log_returns_empty_list(self):
+        assert parse_sent_messages_log("") == []
+
+
+class TestBuildInstruction:
+    """The prompt has two flavors: solo (just the task + submission
+    protocol) and coop (also documents the messaging helpers)."""
+
+    def test_solo_omits_messaging_section(self):
+        text = build_instruction("Implement feature X")
+        assert "Implement feature X" in text
+        assert "patch.txt" in text
+        # Solo runs don't see the coop tools.
+        assert "coop-send" not in text
+        assert "coop-recv" not in text
+
+    def test_coop_mentions_messaging_helpers(self):
+        text = build_instruction(
+            "Implement feature X",
+            agents=["agent1", "agent2"],
+            agent_id="agent1",
+        )
+        assert "Implement feature X" in text
+        assert "coop-send" in text
+        assert "coop-recv" in text
+        # Names the partner agent so Claude knows who to message.
+        assert "agent2" in text
+
+    def test_coop_with_self_only_still_solo_shape(self):
+        # If somehow only one agent is listed, treat as solo prompt.
+        text = build_instruction(
+            "Implement feature X",
+            agents=["agent1"],
+            agent_id="agent1",
+        )
+        assert "coop-send" not in text
+
+    def test_git_section_only_when_git_enabled(self):
+        without_git = build_instruction(
+            "Implement feature X",
+            agents=["agent1", "agent2"],
+            agent_id="agent1",
+            git_enabled=False,
+        )
+        with_git = build_instruction(
+            "Implement feature X",
+            agents=["agent1", "agent2"],
+            agent_id="agent1",
+            git_enabled=True,
+        )
+        assert "## Git collaboration" not in without_git
+        assert "## Git collaboration" in with_git
+        # Must teach the remote name and partner-branch shape.
+        assert "team" in with_git
+        assert "team/agent2" in with_git
+
+    def test_git_section_absent_in_solo(self):
+        text = build_instruction("X", git_enabled=True)  # no agents -> solo
+        assert "## Git collaboration" not in text
+
+
+class TestBuildGitSetupCommand:
+    """Pure helper that emits the shell snippet for configuring a fresh
+    container as a participant in the shared git remote."""
+
+    def test_contains_required_steps(self):
+        cmd = build_git_setup_command(
+            agent_id="agent1",
+            server_url="git://cooperbench-git:9418/abc/repo.git",
+        )
+        # git identity (so commits/pushes work)
+        assert "git config user.email" in cmd
+        assert "git config user.name" in cmd
+        # team remote pointing at the server
+        assert "git remote add team git://cooperbench-git:9418/abc/repo.git" in cmd
+        # agent-named branch
+        assert "git checkout -b agent1" in cmd
+        # initial push so peers can fetch
+        assert "git push" in cmd
+        assert "team" in cmd
+        assert "agent1" in cmd
+
+    def test_idempotent_on_pre_existing_remote(self):
+        """The connector handles the case where the remote already exists
+        (a previous setup ran).  The command must include a recovery path."""
+        cmd = build_git_setup_command(
+            agent_id="agent1",
+            server_url="git://cooperbench-git:9418/abc/repo.git",
+        )
+        assert "git remote set-url" in cmd
+
+    def test_server_url_shell_quoted(self):
+        """URLs come from external data; we mustn't allow shell injection."""
+        cmd = build_git_setup_command(
+            agent_id="agent1",
+            server_url="git://h:9418/r;rm -rf /",
+        )
+        # The dangerous payload must not appear unquoted; the only safe
+        # form is inside single-quotes, where ; loses its shell meaning.
+        assert "rm -rf /'" in cmd or "'rm -rf /'" in cmd or "\\;rm" in cmd
+
+
+class TestAdapterGitWiring:
+    """When git is enabled, the adapter must:
+       (a) join the shared docker network,
+       (b) run git setup in the container before invoking claude,
+       (c) include the git section in the prompt.
+    """
+
+    def _responses(self, stream_json, session_jsonl, patch_text):
+        return {
+            "claude-setup.sh": {"output": "+ installed\n", "returncode": 0},
+            "claude --verbose": {"output": "", "returncode": 0},
+            "claude-stream.jsonl": {"output": stream_json, "returncode": 0},
+            "find /tmp/claude-cfg/projects": {"output": session_jsonl, "returncode": 0},
+            "patch.txt": {"output": patch_text, "returncode": 0},
+        }
+
+    def test_git_setup_runs_when_git_enabled(
+        self, fake_env_factory, stream_json_success, session_jsonl_one_turn
+    ):
+        env = fake_env_factory(self._responses(stream_json_success, session_jsonl_one_turn, ""))
+        captured: dict[str, object] = {}
+
+        def _capture_env(image, *, network=None, extra_run_args=None, timeout=7200):
+            captured["network"] = network
+            captured["extra_run_args"] = extra_run_args or []
+            return env
+
+        with mock_patch(
+            "cooperbench.agents.claude_code.adapter._build_environment",
+            side_effect=_capture_env,
+        ):
+            runner = get_runner("claude_code")
+            runner.run(
+                task="t",
+                image="cooperbench/example:task1",
+                model_name="claude-sonnet-4-5",
+                agents=["agent1", "agent2"],
+                agent_id="agent1",
+                comm_url="redis://localhost:6379#run:abc",
+                git_server_url="git://cooperbench-git:9418/abc/repo.git",
+                git_enabled=True,
+                messaging_enabled=True,
+                config={"git_network": "cooperbench"},
+            )
+
+        # Joins shared docker network.
+        assert captured["network"] == "cooperbench"
+        # Some command issued must configure the team remote.
+        joined = "\n".join(env.executed)
+        assert "git remote add team git://cooperbench-git:9418/abc/repo.git" in joined
+        assert "git checkout -b agent1" in joined
+
+    def test_git_setup_skipped_when_git_disabled(
+        self, fake_env_factory, stream_json_success, session_jsonl_one_turn
+    ):
+        env = fake_env_factory(self._responses(stream_json_success, session_jsonl_one_turn, ""))
+
+        with mock_patch(
+            "cooperbench.agents.claude_code.adapter._build_environment",
+            return_value=env,
+        ):
+            runner = get_runner("claude_code")
+            runner.run(
+                task="t",
+                image="cooperbench/example:task1",
+                model_name="claude-sonnet-4-5",
+                agents=["agent1", "agent2"],
+                agent_id="agent1",
+                comm_url="redis://localhost:6379#run:abc",
+                git_enabled=False,
+                messaging_enabled=True,
+            )
+
+        joined = "\n".join(env.executed)
+        assert "git remote add team" not in joined
+        assert "git checkout -b agent1" not in joined
+
+
+class TestResolveCredentials:
+    """The adapter accepts either an API key or an OAuth token, with the
+    OAuth token also discoverable from ``~/.claude/.credentials.json`` so
+    a host that's already logged in via ``claude login`` works out of the
+    box (subscription-based usage, no API key required).
+    """
+
+    def test_api_key_wins(self, monkeypatch, tmp_path):
+        monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-test")
+        monkeypatch.setenv("CLAUDE_CODE_OAUTH_TOKEN", "oat-test")
+        creds = resolve_credentials(credentials_path=tmp_path / "missing.json")
+        assert creds == {"ANTHROPIC_API_KEY": "sk-test"}
+
+    def test_explicit_oauth_env_var(self, monkeypatch, tmp_path):
+        monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+        monkeypatch.setenv("CLAUDE_CODE_OAUTH_TOKEN", "oat-test")
+        creds = resolve_credentials(credentials_path=tmp_path / "missing.json")
+        assert creds == {"CLAUDE_CODE_OAUTH_TOKEN": "oat-test"}
+
+    def test_falls_back_to_credentials_file(self, monkeypatch, tmp_path):
+        monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+        monkeypatch.delenv("CLAUDE_CODE_OAUTH_TOKEN", raising=False)
+        path = tmp_path / "creds.json"
+        path.write_text(
+            json.dumps(
+                {"claudeAiOauth": {"accessToken": "oat-from-file", "expiresAt": 9999999999000}}
+            )
+        )
+        creds = resolve_credentials(credentials_path=path)
+        assert creds == {"CLAUDE_CODE_OAUTH_TOKEN": "oat-from-file"}
+
+    def test_returns_empty_when_nothing_available(self, monkeypatch, tmp_path):
+        monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+        monkeypatch.delenv("CLAUDE_CODE_OAUTH_TOKEN", raising=False)
+        creds = resolve_credentials(credentials_path=tmp_path / "absent.json")
+        assert creds == {}
+
+    def test_corrupt_credentials_file_returns_empty(self, monkeypatch, tmp_path):
+        monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+        monkeypatch.delenv("CLAUDE_CODE_OAUTH_TOKEN", raising=False)
+        path = tmp_path / "creds.json"
+        path.write_text("not json at all")
+        assert resolve_credentials(credentials_path=path) == {}
+
+
+class TestRegistration:
+    def test_claude_code_is_registered(self):
+        assert "claude_code" in list_agents()
+
+    def test_get_runner_returns_instance(self):
+        runner = get_runner("claude_code")
+        assert runner is not None
+        assert hasattr(runner, "run")
+        assert callable(runner.run)
+
+
+class TestAdapterRun:
+    """End-to-end behavior of ``ClaudeCodeRunner.run`` with the env stubbed."""
+
+    def _responses(self, stream_json, session_jsonl, patch_text, *, install_rc=0):
+        return {
+            "claude-setup.sh": {"output": "+ claude installed\n", "returncode": install_rc},
+            "claude --verbose": {"output": "", "returncode": 0},
+            "claude-stream.jsonl": {"output": stream_json, "returncode": 0},
+            "find /tmp/claude-cfg/projects": {"output": session_jsonl, "returncode": 0},
+            "patch.txt": {"output": patch_text, "returncode": 0},
+        }
+
+    def test_run_returns_agent_result(self, fake_env_factory, stream_json_success, session_jsonl_one_turn):
+        env = fake_env_factory(
+            self._responses(
+                stream_json_success,
+                session_jsonl_one_turn,
+                "diff --git a/x b/x\n+hello\n",
+            )
+        )
+
+        with mock_patch(
+            "cooperbench.agents.claude_code.adapter._build_environment",
+            return_value=env,
+        ):
+            runner = get_runner("claude_code")
+            result = runner.run(
+                task="implement feature X",
+                image="cooperbench/example:task1",
+                model_name="claude-sonnet-4-6",
+            )
+
+        assert isinstance(result, AgentResult)
+        assert result.status == "Submitted"
+        assert result.patch.startswith("diff --git")
+        assert result.cost == pytest.approx(0.12)
+        assert result.steps == 5
+        assert result.input_tokens == 1000
+        assert result.output_tokens == 200
+        assert result.cache_read_tokens == 50
+        assert result.cache_write_tokens == 10
+        assert result.messages == [{"role": "user", "content": "Hello"}]
+        assert env.cleaned is True
+
+    def test_invocation_includes_required_flags(self, fake_env_factory, stream_json_success, session_jsonl_one_turn):
+        env = fake_env_factory(
+            self._responses(stream_json_success, session_jsonl_one_turn, "")
+        )
+
+        with mock_patch(
+            "cooperbench.agents.claude_code.adapter._build_environment",
+            return_value=env,
+        ):
+            runner = get_runner("claude_code")
+            runner.run(
+                task="implement feature X",
+                image="cooperbench/example:task1",
+                model_name="claude-sonnet-4-6",
+            )
+
+        claude_cmds = [c for c in env.executed if "claude --verbose" in c]
+        assert len(claude_cmds) == 1
+        claude_cmd = claude_cmds[0]
+        assert "claude " in claude_cmd
+        assert "--output-format=stream-json" in claude_cmd or "--output-format stream-json" in claude_cmd
+        assert "--print" in claude_cmd or " -p " in claude_cmd
+        assert "--permission-mode=bypassPermissions" in claude_cmd or "bypassPermissions" in claude_cmd
+        assert "--verbose" in claude_cmd
+        # The instruction is written to a file and read back with `cat`,
+        # not interpolated into the claude command itself.  Verify the
+        # instruction landed in one of the heredoc-write commands.
+        assert any("implement feature X" in c for c in env.executed)
+        # And that the claude command reads the instruction from that file.
+        assert "claude-instruction.txt" in claude_cmd
+
+    def test_model_name_propagated_via_env_in_invocation(
+        self, fake_env_factory, stream_json_success, session_jsonl_one_turn
+    ):
+        env = fake_env_factory(
+            self._responses(stream_json_success, session_jsonl_one_turn, "")
+        )
+
+        with mock_patch(
+            "cooperbench.agents.claude_code.adapter._build_environment",
+            return_value=env,
+        ):
+            runner = get_runner("claude_code")
+            runner.run(
+                task="t",
+                image="cooperbench/example:task1",
+                model_name="anthropic/claude-sonnet-4-6",
+            )
+
+        claude_cmds = [c for c in env.executed if "claude --verbose" in c]
+        assert len(claude_cmds) == 1
+        claude_cmd = claude_cmds[0]
+        # The "anthropic/" prefix is stripped before passing as ANTHROPIC_MODEL.
+        assert "claude-sonnet-4-6" in claude_cmd
+        assert "anthropic/claude-sonnet-4-6" not in claude_cmd
+
+    def test_error_status_when_install_fails(self, fake_env_factory):
+        env = fake_env_factory(
+            {"claude-setup.sh": {"output": "npm: command not found", "returncode": 127}}
+        )
+
+        with mock_patch(
+            "cooperbench.agents.claude_code.adapter._build_environment",
+            return_value=env,
+        ):
+            runner = get_runner("claude_code")
+            result = runner.run(
+                task="t",
+                image="cooperbench/example:task1",
+                model_name="claude-sonnet-4-6",
+            )
+
+        assert result.status == "Error"
+        assert result.error is not None
+        assert result.patch == ""
+        assert env.cleaned is True
+
+    def test_empty_patch_when_agent_writes_no_file(
+        self, fake_env_factory, stream_json_success, session_jsonl_one_turn
+    ):
+        env = fake_env_factory(
+            self._responses(stream_json_success, session_jsonl_one_turn, "")
+        )
+
+        with mock_patch(
+            "cooperbench.agents.claude_code.adapter._build_environment",
+            return_value=env,
+        ):
+            runner = get_runner("claude_code")
+            result = runner.run(
+                task="t",
+                image="cooperbench/example:task1",
+                model_name="claude-sonnet-4-6",
+            )
+
+        assert result.status == "Submitted"
+        assert result.patch == ""
+
+    def test_limits_exceeded_propagated(self, fake_env_factory, session_jsonl_one_turn):
+        stream = json.dumps(
+            {
+                "type": "result",
+                "subtype": "error_max_turns",
+                "total_cost_usd": 0.03,
+                "num_turns": 50,
+                "usage": {"input_tokens": 0, "output_tokens": 0},
+                "is_error": True,
+            }
+        )
+        env = fake_env_factory(self._responses(stream, session_jsonl_one_turn, ""))
+
+        with mock_patch(
+            "cooperbench.agents.claude_code.adapter._build_environment",
+            return_value=env,
+        ):
+            runner = get_runner("claude_code")
+            result = runner.run(
+                task="t",
+                image="cooperbench/example:task1",
+                model_name="claude-sonnet-4-6",
+            )
+
+        assert result.status == "LimitsExceeded"

--- a/tests/agents/claude_code/test_parsers.py
+++ b/tests/agents/claude_code/test_parsers.py
@@ -1,0 +1,251 @@
+"""Unit tests for Claude Code stream-json and session-JSONL parsers.
+
+These parsers must remain pure functions that take a string (or list of
+JSONL lines) and return structured data, so they can be tested without
+running the CLI or a container.
+"""
+
+import json
+
+import pytest
+
+from cooperbench.agents.claude_code.parsers import (
+    StreamSummary,
+    parse_session_jsonl,
+    parse_stream_json,
+)
+
+
+class TestParseStreamJson:
+    """Stream-json from ``claude --print --output-format=stream-json``.
+
+    The Claude Code CLI emits one JSON object per line. The final line of
+    a completed run is ``{"type": "result", ..., "total_cost_usd": <float>,
+    "usage": {...}, "num_turns": <int>}``.  We need to extract the
+    authoritative cost + token totals from that line.
+    """
+
+    def test_extracts_total_cost_and_tokens_from_result_event(self):
+        stream = "\n".join(
+            [
+                json.dumps({"type": "system", "subtype": "init"}),
+                json.dumps({"type": "assistant", "message": {"content": []}}),
+                json.dumps(
+                    {
+                        "type": "result",
+                        "subtype": "success",
+                        "total_cost_usd": 0.0421,
+                        "num_turns": 7,
+                        "usage": {
+                            "input_tokens": 1200,
+                            "output_tokens": 350,
+                            "cache_read_input_tokens": 8800,
+                            "cache_creation_input_tokens": 200,
+                        },
+                    }
+                ),
+            ]
+        )
+        summary = parse_stream_json(stream)
+        assert isinstance(summary, StreamSummary)
+        assert summary.cost == pytest.approx(0.0421)
+        assert summary.steps == 7
+        assert summary.input_tokens == 1200
+        assert summary.output_tokens == 350
+        assert summary.cache_read_tokens == 8800
+        assert summary.cache_write_tokens == 200
+
+    def test_missing_result_event_returns_zero_values(self):
+        stream = json.dumps({"type": "system", "subtype": "init"})
+        summary = parse_stream_json(stream)
+        assert summary.cost == 0.0
+        assert summary.steps == 0
+        assert summary.input_tokens == 0
+        assert summary.output_tokens == 0
+
+    def test_skips_blank_and_non_json_lines(self):
+        stream = "\n".join(
+            [
+                "",
+                "not-json garbage",
+                json.dumps(
+                    {
+                        "type": "result",
+                        "total_cost_usd": 0.5,
+                        "num_turns": 3,
+                        "usage": {"input_tokens": 10, "output_tokens": 5},
+                    }
+                ),
+                "",
+            ]
+        )
+        summary = parse_stream_json(stream)
+        assert summary.cost == pytest.approx(0.5)
+        assert summary.steps == 3
+
+    def test_empty_input_returns_zero_summary(self):
+        summary = parse_stream_json("")
+        assert summary.cost == 0.0
+        assert summary.steps == 0
+
+    def test_status_is_error_when_result_event_signals_error(self):
+        stream = json.dumps(
+            {
+                "type": "result",
+                "subtype": "error_max_turns",
+                "total_cost_usd": 0.01,
+                "num_turns": 30,
+                "usage": {"input_tokens": 0, "output_tokens": 0},
+                "is_error": True,
+            }
+        )
+        summary = parse_stream_json(stream)
+        assert summary.status == "LimitsExceeded"
+        assert summary.cost == pytest.approx(0.01)
+
+    def test_status_is_submitted_when_result_succeeds(self):
+        stream = json.dumps(
+            {
+                "type": "result",
+                "subtype": "success",
+                "total_cost_usd": 0.0,
+                "num_turns": 2,
+                "usage": {"input_tokens": 0, "output_tokens": 0},
+            }
+        )
+        summary = parse_stream_json(stream)
+        assert summary.status == "Submitted"
+
+    def test_status_is_error_when_no_result_event(self):
+        summary = parse_stream_json('{"type": "system"}')
+        assert summary.status == "Error"
+
+
+class TestParseSessionJsonl:
+    """Per-session JSONL written under ``$CLAUDE_CONFIG_DIR/projects/...``.
+
+    Each line is a normalized turn (user / assistant / tool_use /
+    tool_result).  We convert it to OpenAI-style chat messages that
+    CooperBench's downstream extractor expects (``role`` + ``content``).
+    """
+
+    def test_user_turn_becomes_user_message(self):
+        line = json.dumps(
+            {
+                "type": "user",
+                "message": {"role": "user", "content": "Hello"},
+                "timestamp": "2026-01-01T00:00:00Z",
+            }
+        )
+        messages = parse_session_jsonl(line)
+        assert messages == [{"role": "user", "content": "Hello"}]
+
+    def test_assistant_text_turn_becomes_assistant_message(self):
+        line = json.dumps(
+            {
+                "type": "assistant",
+                "message": {
+                    "role": "assistant",
+                    "content": [{"type": "text", "text": "Looking at the code."}],
+                },
+                "timestamp": "2026-01-01T00:00:01Z",
+            }
+        )
+        messages = parse_session_jsonl(line)
+        assert messages == [{"role": "assistant", "content": "Looking at the code."}]
+
+    def test_assistant_tool_use_serialized_into_content(self):
+        line = json.dumps(
+            {
+                "type": "assistant",
+                "message": {
+                    "role": "assistant",
+                    "content": [
+                        {
+                            "type": "tool_use",
+                            "id": "tool_1",
+                            "name": "Bash",
+                            "input": {"command": "ls"},
+                        },
+                    ],
+                },
+                "timestamp": "2026-01-01T00:00:02Z",
+            }
+        )
+        messages = parse_session_jsonl(line)
+        assert len(messages) == 1
+        msg = messages[0]
+        assert msg["role"] == "assistant"
+        # Tool call should appear in the content string so downstream
+        # ``"send_message" in content`` checks don't blow up.
+        assert "Bash" in msg["content"]
+        assert "ls" in msg["content"]
+
+    def test_tool_result_becomes_user_message(self):
+        line = json.dumps(
+            {
+                "type": "user",
+                "message": {
+                    "role": "user",
+                    "content": [
+                        {
+                            "type": "tool_result",
+                            "tool_use_id": "tool_1",
+                            "content": "file1\nfile2",
+                        }
+                    ],
+                },
+                "timestamp": "2026-01-01T00:00:03Z",
+            }
+        )
+        messages = parse_session_jsonl(line)
+        assert len(messages) == 1
+        assert messages[0]["role"] == "user"
+        assert "file1" in messages[0]["content"]
+
+    def test_events_sorted_by_timestamp(self):
+        a = json.dumps(
+            {
+                "type": "user",
+                "message": {"role": "user", "content": "second"},
+                "timestamp": "2026-01-01T00:00:02Z",
+            }
+        )
+        b = json.dumps(
+            {
+                "type": "user",
+                "message": {"role": "user", "content": "first"},
+                "timestamp": "2026-01-01T00:00:01Z",
+            }
+        )
+        messages = parse_session_jsonl("\n".join([a, b]))
+        assert [m["content"] for m in messages] == ["first", "second"]
+
+    def test_malformed_lines_are_skipped(self):
+        good = json.dumps(
+            {
+                "type": "user",
+                "message": {"role": "user", "content": "ok"},
+                "timestamp": "2026-01-01T00:00:00Z",
+            }
+        )
+        text = "\n".join(["", "not json", good])
+        messages = parse_session_jsonl(text)
+        assert messages == [{"role": "user", "content": "ok"}]
+
+    def test_empty_input_returns_empty_list(self):
+        assert parse_session_jsonl("") == []
+
+    def test_content_field_never_none(self):
+        """Downstream code does ``"send_message" in msg["content"]`` so
+        ``content`` must always be a string, never ``None``."""
+        line = json.dumps(
+            {
+                "type": "assistant",
+                "message": {"role": "assistant", "content": None},
+                "timestamp": "2026-01-01T00:00:00Z",
+            }
+        )
+        messages = parse_session_jsonl(line)
+        for m in messages:
+            assert isinstance(m["content"], str)


### PR DESCRIPTION
## Summary

- New `claude_code` agent adapter wrapping the official `@anthropic-ai/claude-code` CLI; supports solo, coop (Redis messaging), and coop+git (shared `cooperbench-git` remote) settings.
- 45 unit tests covering stream-json + session-JSONL parsing, credential resolution, comm URL rewriting, prompt branching, and git setup.
- End-to-end verified on `dottxt_ai_outlines_task/1371` features 1+2 — coop+git scores **2/2 features pass**.

## How it works

- Installs `claude-code` inside the task container at runtime (npm).
- Invokes `claude --print --output-format=stream-json --permission-mode=bypassPermissions`; parses the terminating `result` event for cost/tokens and walks `$CLAUDE_CONFIG_DIR/projects/*/.../*.jsonl` for messages.
- Patch is harvested from `/workspace/repo/patch.txt` (same convention v2 uses).
- Coop: copies an in-container Python messaging helper that wraps Redis, exposes it as `coop-send`/`coop-recv`/`coop-broadcast`/`coop-peek`/`coop-agents` shell commands, rewrites `localhost`→`host.docker.internal` in the comm URL, and launches the container with `--add-host=host.docker.internal:host-gateway`.
- Coop+git: joins the `cooperbench` docker network, configures `team` remote against the shared git server, creates an agent-named branch, and pushes initial state. The prompt teaches the fetch/merge/push workflow.
- Credentials: resolves in order `ANTHROPIC_API_KEY` → `CLAUDE_CODE_OAUTH_TOKEN` → `~/.claude/.credentials.json` (subscription-based usage).

## End-to-end smoke results

| Run | Features | Pass rate | Notes |
| --- | --- | --- | --- |
| solo `-f 1` | 1 | n/a (eval needs pair) | $0.53, 211-line diff |
| coop (no git) | 1, 2 | 1/2 | classic merge-failure: agent2's patch fails to apply on agent1's restructured file |
| coop `--git` | 1, 2 | **2/2** | each agent fetched/merged peer's branch via `team` and rebuilt `patch.txt` from merged tree |

## Test plan

- [ ] CI runs `ruff check`, `ruff format --check`, `mypy`, and `pytest` (all green locally — 204 passed, 63 integration skipped).
- [ ] Manual: `uv run cooperbench run -a claude_code -m claude-sonnet-4-5 -r dottxt_ai_outlines_task -t 1371 -f 1,2 --setting coop --git --backend docker` followed by `uv run cooperbench eval`.
- [ ] Confirm `ANTHROPIC_API_KEY` (or `CLAUDE_CODE_OAUTH_TOKEN`, or a `~/.claude/.credentials.json` produced by `claude login`) is present on the host before running.

## Follow-ups (not in this PR)

- MCP-based collaboration tools (instead of shell-wrappers) for a more polished surface.
- `--max-turns`, `--effort`, and other Claude Code knobs as `agent-config` flags.
