### PR TITLE
team mode: fs mirror, typed protocol, MCP server, in-loop refresh

### DIFF
--- a/src/cooperbench/agents/_team/__init__.py
+++ b/src/cooperbench/agents/_team/__init__.py
@@ -24,10 +24,14 @@ This module exports the host-side helpers; the in-container
 ``coop-task-*`` shell tools are wired up by ``install_snippet.sh``.
 """
 
+from cooperbench.agents._team.fs_mirror import mirror_to_directory
+from cooperbench.agents._team.loop_refresh import TeamPoller, format_task_summary, poll_team_state
 from cooperbench.agents._team.metrics import compute_metrics
 from cooperbench.agents._team.prompt import build_team_instruction
+from cooperbench.agents._team.protocol import ProtocolClient
 from cooperbench.agents._team.runtime import (
     CONTAINER_SCRATCHPAD_DIR,
+    CONTAINER_TASKS_MIRROR_DIR,
     build_team_env,
     scratchpad_mount_args,
 )
@@ -35,9 +39,15 @@ from cooperbench.agents._team.task_list import TaskListClient
 
 __all__ = [
     "CONTAINER_SCRATCHPAD_DIR",
+    "CONTAINER_TASKS_MIRROR_DIR",
+    "ProtocolClient",
     "TaskListClient",
+    "TeamPoller",
     "build_team_env",
     "build_team_instruction",
     "compute_metrics",
+    "format_task_summary",
+    "mirror_to_directory",
+    "poll_team_state",
     "scratchpad_mount_args",
 ]

--- a/src/cooperbench/agents/_team/coop_task.py
+++ b/src/cooperbench/agents/_team/coop_task.py
@@ -121,6 +121,165 @@ def cmd_update(args: argparse.Namespace) -> int:
     return 0
 
 
+def _snapshot_to_directory(client, ns: str, target: str) -> None:
+    """Mirror the full task list under ``target`` as one JSON file per task.
+
+    Inlined here (rather than importing ``cooperbench.agents._team.fs_mirror``)
+    because the in-container helper script must be self-contained — the
+    cooperbench package isn't installed in the agent image.  The on-disk
+    layout matches what ``fs_mirror.mirror_to_directory`` produces.
+    """
+    import os as _os
+    import tempfile as _tempfile
+
+    _os.makedirs(target, exist_ok=True)
+    all_ids = sorted(_decode(m) for m in client.smembers(f"{ns}:tasks:all"))
+    live = set(all_ids)
+
+    def _atomic_write(path: str, content: str) -> None:
+        dirname = _os.path.dirname(path) or "."
+        _os.makedirs(dirname, exist_ok=True)
+        tmp = _tempfile.NamedTemporaryFile(
+            mode="w",
+            dir=dirname,
+            prefix=f".{_os.path.basename(path)}.",
+            delete=False,
+            encoding="utf-8",
+        )
+        try:
+            tmp.write(content)
+            tmp.flush()
+            _os.fsync(tmp.fileno())
+        finally:
+            tmp.close()
+        _os.replace(tmp.name, path)
+
+    for tid in all_ids:
+        raw = {_decode(k): _decode(v) for k, v in client.hgetall(f"{ns}:task:{tid}").items()}
+        if not raw:
+            continue
+        try:
+            raw["created_at"] = float(raw["created_at"])
+        except (KeyError, ValueError):
+            pass
+        try:
+            raw["metadata"] = json.loads(raw.get("metadata", "{}"))
+        except (TypeError, json.JSONDecodeError):
+            raw["metadata"] = {}
+        _atomic_write(_os.path.join(target, f"{tid}.json"), json.dumps(raw, indent=2, default=str))
+
+    # Remove stale per-task files (tasks that have been deleted).
+    for fname in _os.listdir(target):
+        if not fname.endswith(".json") or fname.startswith("_"):
+            continue
+        if fname[:-5] not in live:
+            try:
+                _os.remove(_os.path.join(target, fname))
+            except OSError:
+                pass
+
+    import time as _time
+
+    _atomic_write(
+        _os.path.join(target, "_index.json"),
+        json.dumps({"updated_at": _time.time(), "ids": all_ids}, indent=2),
+    )
+
+    log_raw = client.lrange(f"{ns}:task-log", 0, -1)
+    log_lines = []
+    for line in log_raw:
+        try:
+            log_lines.append(json.loads(_decode(line)))
+        except json.JSONDecodeError:
+            continue
+    log_text = "\n".join(json.dumps(e) for e in log_lines)
+    if log_text:
+        log_text += "\n"
+    _atomic_write(_os.path.join(target, "_log.jsonl"), log_text)
+
+
+def cmd_request(args: argparse.Namespace) -> int:
+    """Send a typed request to ``recipient``; optionally block for a response."""
+    client, ns = _client_and_ns()
+    import time as _time
+    import uuid as _uuid
+
+    body = args.body if args.body is not None else sys.stdin.read()
+    rid = _uuid.uuid4().hex[:10]
+    fields = {
+        "id": rid,
+        "from": _agent_id(),
+        "to": args.recipient,
+        "kind": args.kind,
+        "body": body,
+        "ts": str(_time.time()),
+    }
+    client.hset(f"{ns}:requests:open:{rid}", mapping=fields)
+    client.sadd(f"{ns}:requests:by_recipient:{args.recipient}", rid)
+    _log(client, ns, kind="request", request_id=rid, by=_agent_id(), to=args.recipient, request_kind=args.kind)
+
+    if args.wait is None:
+        print(rid)
+        return 0
+
+    # Block on response.
+    timeout = max(0.05, float(args.wait))
+    result = client.blpop([f"{ns}:responses:{rid}"], timeout=timeout)
+    if result is None:
+        print(f"timed out waiting for response to {rid}", file=sys.stderr)
+        return 5
+    _key, raw = result
+    print(_decode(raw))
+    return 0
+
+
+def cmd_respond(args: argparse.Namespace) -> int:
+    """Reply to an open request."""
+    client, ns = _client_and_ns()
+    key = f"{ns}:requests:open:{args.request_id}"
+    if not client.exists(key):
+        print(f"unknown request {args.request_id}", file=sys.stderr)
+        return 6
+    req = {_decode(k): _decode(v) for k, v in client.hgetall(key).items()}
+    if req.get("to") != _agent_id():
+        print(f"request {args.request_id} not addressed to {_agent_id()}", file=sys.stderr)
+        return 7
+
+    import time as _time
+
+    body = args.body if args.body is not None else sys.stdin.read()
+    response = {
+        "id": args.request_id,
+        "from": _agent_id(),
+        "to": req.get("from"),
+        "body": body,
+        "ts": _time.time(),
+    }
+    client.rpush(f"{ns}:responses:{args.request_id}", json.dumps(response))
+    client.delete(key)
+    client.srem(f"{ns}:requests:by_recipient:{_agent_id()}", args.request_id)
+    _log(client, ns, kind="response", request_id=args.request_id, by=_agent_id(), to=req.get("from"))
+    return 0
+
+
+def cmd_pending(_args: argparse.Namespace) -> int:
+    """List open requests addressed to this agent."""
+    client, ns = _client_and_ns()
+    ids = sorted(_decode(m) for m in client.smembers(f"{ns}:requests:by_recipient:{_agent_id()}"))
+    out = []
+    for rid in ids:
+        raw = {_decode(k): _decode(v) for k, v in client.hgetall(f"{ns}:requests:open:{rid}").items()}
+        if not raw:
+            continue
+        try:
+            raw["ts"] = float(raw["ts"])
+        except (KeyError, ValueError):
+            pass
+        out.append(raw)
+    print(json.dumps(out, indent=2))
+    return 0
+
+
 def cmd_list(args: argparse.Namespace) -> int:
     client, ns = _client_and_ns()
     ids = sorted(_decode(m) for m in client.smembers(f"{ns}:tasks:all"))
@@ -145,6 +304,17 @@ def cmd_list(args: argparse.Namespace) -> int:
             raw["metadata"] = {}
         out.append(raw)
     print(json.dumps(out, indent=2))
+
+    # Side effect: snapshot the *full* list to the scratchpad so agents
+    # can also browse it via ``ls /workspace/shared/tasks/`` without
+    # needing this CLI.  Triggered on every list call (cheap; no inotify
+    # required).
+    mirror_target = os.environ.get("CB_TEAM_TASKS_DIR")
+    if mirror_target:
+        try:
+            _snapshot_to_directory(client, ns, mirror_target)
+        except OSError:
+            pass  # mirror is best-effort
     return 0
 
 
@@ -171,6 +341,26 @@ def main(argv: list[str] | None = None) -> int:
     p_list.add_argument("--mine", action="store_true")
     p_list.add_argument("--open", dest="open_only", action="store_true")
     p_list.set_defaults(func=cmd_list)
+
+    p_req = sub.add_parser("request")
+    p_req.add_argument("recipient")
+    p_req.add_argument("kind")
+    p_req.add_argument("body", nargs="?", default=None)
+    p_req.add_argument(
+        "--wait",
+        type=float,
+        default=None,
+        help="block up to N seconds for a response; if omitted, returns request_id and exits",
+    )
+    p_req.set_defaults(func=cmd_request)
+
+    p_resp = sub.add_parser("respond")
+    p_resp.add_argument("request_id")
+    p_resp.add_argument("body", nargs="?", default=None)
+    p_resp.set_defaults(func=cmd_respond)
+
+    p_pending = sub.add_parser("pending")
+    p_pending.set_defaults(func=cmd_pending)
 
     args = parser.parse_args(argv)
     return args.func(args)

--- a/src/cooperbench/agents/_team/fs_mirror.py
+++ b/src/cooperbench/agents/_team/fs_mirror.py
@@ -1,0 +1,94 @@
+"""Filesystem mirror of the Redis task list.
+
+Mirrors the CC team primitive of "tasks as on-disk files agents can
+``ls`` and ``cat``" without giving up the atomicity Redis gives us.
+The mirror is the read-only projection; Redis remains the source of
+truth and the only thing that accepts writes.
+
+Layout (relative to a caller-supplied target directory):
+
+    <task_id>.json       one file per task, fields mirror
+                         ``TaskListClient.get(task_id)``
+    _index.json          {"updated_at": <float>, "ids": [...]} —
+                         cheap directory listing
+    _log.jsonl           audit log copy (one JSON event per line)
+
+Snapshots are eventually consistent and triggered explicitly by the
+in-container ``coop-task-list`` CLI (and by the team runner at the
+start of each run).  Each file is written via ``tempfile + replace``
+so a concurrent reader either sees the old or new content, never a
+half-written one.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import tempfile
+import time
+from pathlib import Path
+
+from cooperbench.agents._team.task_list import TaskListClient
+
+
+def _atomic_write_text(path: Path, content: str) -> None:
+    """Write ``content`` to ``path`` such that readers see either the old
+    or new file but never a partial write."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    # NamedTemporaryFile gives us a unique name in the same directory
+    # so the final ``os.replace`` is rename(2) on a single filesystem
+    # and therefore atomic.
+    tmp = tempfile.NamedTemporaryFile(
+        mode="w",
+        dir=str(path.parent),
+        prefix=f".{path.name}.",
+        delete=False,
+        encoding="utf-8",
+    )
+    try:
+        tmp.write(content)
+        tmp.flush()
+        os.fsync(tmp.fileno())
+    finally:
+        tmp.close()
+    os.replace(tmp.name, path)
+
+
+def mirror_to_directory(client: TaskListClient, target_dir: str | Path) -> None:
+    """Snapshot the current task list to ``target_dir``.
+
+    Idempotent and safe to call from any process holding a
+    ``TaskListClient``.  Removes files for tasks that have been
+    deleted from Redis since the last snapshot.
+    """
+    target = Path(target_dir)
+    target.mkdir(parents=True, exist_ok=True)
+
+    tasks = client.list()
+    live_ids = {t["id"] for t in tasks}
+
+    # 1. Per-task files.
+    for task in tasks:
+        path = target / f"{task['id']}.json"
+        _atomic_write_text(path, json.dumps(task, indent=2, default=str))
+
+    # 2. Remove stale files (tasks that no longer exist in Redis).
+    for existing in target.glob("*.json"):
+        if existing.name.startswith("_"):
+            continue
+        if existing.stem not in live_ids:
+            try:
+                existing.unlink()
+            except OSError:
+                pass
+
+    # 3. Index file — cheap path for ``ls``-equivalent reads.
+    index = {"updated_at": time.time(), "ids": sorted(live_ids)}
+    _atomic_write_text(target / "_index.json", json.dumps(index, indent=2))
+
+    # 4. Audit log copy.
+    events = client.log_events()
+    log_text = "\n".join(json.dumps(e) for e in events)
+    if log_text:
+        log_text += "\n"
+    _atomic_write_text(target / "_log.jsonl", log_text)

--- a/src/cooperbench/agents/_team/install_snippet.sh
+++ b/src/cooperbench/agents/_team/install_snippet.sh
@@ -17,3 +17,12 @@ exec python3 /tmp/cb-coop-task.py $sub "\$@"
 EOF
     chmod +x "/usr/local/bin/coop-task-$sub"
 done
+
+# Typed coop-request / coop-respond / coop-pending: same helper, different verb.
+for verb in request respond pending; do
+    cat >"/usr/local/bin/coop-$verb" <<EOF
+#!/bin/bash
+exec python3 /tmp/cb-coop-task.py $verb "\$@"
+EOF
+    chmod +x "/usr/local/bin/coop-$verb"
+done

--- a/src/cooperbench/agents/_team/loop_refresh.py
+++ b/src/cooperbench/agents/_team/loop_refresh.py
@@ -1,0 +1,132 @@
+"""In-loop task-list refresh helpers for Python-loop adapters.
+
+Python-loop adapters (mini_swe_agent_v2, swe_agent, openhands_sdk) own
+their agent loop and already poll the inbox between steps.  When team
+mode is active we want the same automatic surfacing for the task list:
+just before each LLM call, the adapter calls ``poll_team_state()``,
+gets back a short summary string, and prepends it as a user-role
+message.  The LLM sees the live state of the shared list without
+needing to remember to call ``coop-task-list``.
+
+The helpers are designed to be cheap and failure-tolerant: when
+team-mode env vars are unset (solo / coop), or Redis is unreachable,
+they return ``None`` and the adapter skips the injection.  Nothing
+about this should ever crash an agent loop.
+"""
+
+from __future__ import annotations
+
+import os
+from typing import Any
+
+import redis
+
+
+def _client_from_env() -> Any:
+    """Build a Redis client from the in-container env vars.
+
+    Module-level seam so tests can monkey-patch in a fakeredis instance.
+    Raises any redis error the caller is expected to swallow.
+    """
+    url = os.environ["CB_TEAM_REDIS_URL"]
+    if "#" in url:
+        url, _ = url.split("#", 1)
+    return redis.from_url(url, socket_timeout=2)
+
+
+def format_task_summary(tasks: list[dict[str, Any]], *, viewer: str) -> str:
+    """Render a compact, LLM-friendly summary of the task list.
+
+    The format is intentionally terse: the LLM will see this before
+    every step, so we don't want to burn tokens on a verbose table.
+    Status counts come first, then one line per task with the viewer's
+    own tasks called out.
+    """
+    if not tasks:
+        return "[Team task list]: no tasks yet."
+
+    by_status: dict[str, int] = {}
+    for t in tasks:
+        s = t.get("status", "unknown")
+        by_status[s] = by_status.get(s, 0) + 1
+
+    header = ", ".join(f"{k}: {v}" for k, v in sorted(by_status.items()))
+    lines = [f"[Team task list] {header}"]
+    for t in tasks:
+        owner = t.get("owner") or "?"
+        marker = " (you own)" if owner == viewer else ""
+        lines.append(f"  - {t.get('id', '?')} [{t.get('status', '?')}] owner={owner}{marker}: {t.get('title', '')}")
+    return "\n".join(lines)
+
+
+def _read_tasks(client: Any, run_id: str) -> list[dict[str, Any]]:
+    ns = f"cb:{run_id}"
+    ids = sorted((m.decode() if isinstance(m, bytes) else m) for m in client.smembers(f"{ns}:tasks:all"))
+    tasks: list[dict[str, Any]] = []
+    for tid in ids:
+        raw = client.hgetall(f"{ns}:task:{tid}")
+        if not raw:
+            continue
+        tasks.append(
+            {
+                (k.decode() if isinstance(k, bytes) else k): (v.decode() if isinstance(v, bytes) else v)
+                for k, v in raw.items()
+            }
+        )
+    return tasks
+
+
+def poll_team_state() -> str | None:
+    """Read the current task list and return a summary, or ``None``.
+
+    Environment-driven (in-container) variant.  Returns ``None`` when
+    team mode isn't active (env vars missing) or when Redis is
+    unreachable — never raises.  The caller is expected to prepend the
+    returned string as a user-role message before its next LLM query.
+    """
+    if not os.environ.get("CB_TEAM_REDIS_URL") or not os.environ.get("CB_TEAM_AGENT_ID"):
+        return None
+    run_id = os.environ.get("CB_TEAM_RUN_ID", "")
+    viewer = os.environ["CB_TEAM_AGENT_ID"]
+    try:
+        client = _client_from_env()
+        return format_task_summary(_read_tasks(client, run_id), viewer=viewer)
+    except (redis.exceptions.RedisError, OSError, KeyError):
+        return None
+
+
+class TeamPoller:
+    """Host-side per-agent task-list poller for Python-loop adapters.
+
+    Each adapter instance creates one (if team kwargs are set) and
+    calls ``poll()`` between steps; failures are swallowed so the
+    agent loop never crashes because Redis is down.
+    """
+
+    def __init__(self, *, redis_url: str, run_id: str, agent_id: str) -> None:
+        self._url = redis_url
+        self._run_id = run_id
+        self._agent_id = agent_id
+        self._client: Any | None = None
+
+    def _ensure_client(self) -> Any | None:
+        if self._client is not None:
+            return self._client
+        try:
+            url = self._url
+            if "#" in url:
+                url, _ = url.split("#", 1)
+            self._client = redis.from_url(url, socket_timeout=2)
+        except (redis.exceptions.RedisError, OSError):
+            return None
+        return self._client
+
+    def poll(self) -> str | None:
+        """Return a fresh task-list summary, or ``None`` on failure."""
+        client = self._ensure_client()
+        if client is None:
+            return None
+        try:
+            return format_task_summary(_read_tasks(client, self._run_id), viewer=self._agent_id)
+        except (redis.exceptions.RedisError, OSError, KeyError):
+            return None

--- a/src/cooperbench/agents/_team/mcp_server.py
+++ b/src/cooperbench/agents/_team/mcp_server.py
@@ -1,0 +1,189 @@
+"""Stdio MCP server that exposes a ``wait_for_message`` long-poll tool.
+
+The CLI adapters (Claude Code, Codex) run an opaque LLM loop, so we
+can't auto-inject inbox messages between turns the way the Python-loop
+adapters do.  The least-bad alternative is to give them a tool that
+*blocks server-side* until a message arrives — i.e. ``BLPOP`` on the
+Redis inbox — so "watch the inbox" becomes a natural idle behavior
+rather than a busy-loop on ``coop-recv`` returning empty.
+
+We speak JSON-RPC 2.0 over stdio per the MCP spec, supporting the
+minimal surface:
+
+  - ``initialize``
+  - ``tools/list``
+  - ``tools/call``        (only "wait_for_message" today)
+
+Adapters register us via their CLI's config:
+``~/.claude.json`` for Claude Code and ``~/.codex/config.toml`` for
+Codex.  The actual server invocation is just
+``python3 -m cooperbench.agents._team.mcp_server`` with the
+``CB_TEAM_REDIS_URL`` / ``CB_TEAM_AGENT_ID`` env vars set.
+
+The server is intentionally minimal — adding more tools later is just
+another branch in ``_dispatch_tool``.  We don't implement ``logging/*``,
+prompts, resources, or subscriptions; the CLI doesn't need them.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+from typing import Any, Protocol
+
+import redis
+
+PROTOCOL_VERSION = "2025-06-18"
+
+
+class _RedisLike(Protocol):
+    def blpop(self, keys, timeout: float = 0) -> Any: ...
+    def rpush(self, name: str, *values: Any) -> int: ...
+
+
+def build_redis_client_from_env() -> _RedisLike:
+    url = os.environ.get("CB_TEAM_REDIS_URL")
+    if not url:
+        raise RuntimeError("CB_TEAM_REDIS_URL is not set")
+    if "#" in url:
+        url, _ = url.split("#", 1)
+    return redis.from_url(url)
+
+
+class MCPLongPollServer:
+    """In-process MCP server.  ``handle(request)`` returns a response.
+
+    For the real stdio loop, use ``serve_stdio()``.  Tests should call
+    ``handle()`` directly with synthesized request dicts.
+    """
+
+    def __init__(self, redis_client: _RedisLike, agent_id: str) -> None:
+        self._r = redis_client
+        self._me = agent_id
+
+    # --- JSON-RPC dispatch --------------------------------------------
+
+    def handle(self, request: dict[str, Any]) -> dict[str, Any]:
+        method = request.get("method", "")
+        req_id = request.get("id")
+
+        if method == "initialize":
+            return self._wrap(req_id, self._initialize(request.get("params") or {}))
+        if method == "tools/list":
+            return self._wrap(req_id, self._tools_list())
+        if method == "tools/call":
+            params = request.get("params") or {}
+            try:
+                result = self._dispatch_tool(params)
+            except _ToolError as e:
+                return self._error(req_id, code=-32601, message=str(e))
+            return self._wrap(req_id, result)
+        if method == "notifications/initialized":
+            # Client says it's ready; nothing to send back for a notification.
+            # Returning an empty dict is harmless — the stdio loop won't write it.
+            return {}
+        return self._error(req_id, code=-32601, message=f"unknown method {method!r}")
+
+    # --- responses ----------------------------------------------------
+
+    def _wrap(self, req_id: Any, result: Any) -> dict[str, Any]:
+        return {"jsonrpc": "2.0", "id": req_id, "result": result}
+
+    def _error(self, req_id: Any, *, code: int, message: str) -> dict[str, Any]:
+        return {"jsonrpc": "2.0", "id": req_id, "error": {"code": code, "message": message}}
+
+    # --- method impls -------------------------------------------------
+
+    def _initialize(self, _params: dict[str, Any]) -> dict[str, Any]:
+        return {
+            "protocolVersion": PROTOCOL_VERSION,
+            "capabilities": {"tools": {"listChanged": False}},
+            "serverInfo": {"name": "cooperbench-team", "version": "0.1.0"},
+        }
+
+    def _tools_list(self) -> dict[str, Any]:
+        return {
+            "tools": [
+                {
+                    "name": "wait_for_message",
+                    "description": (
+                        "Block server-side until a message arrives in your team inbox, "
+                        "or until timeout_ms elapses.  Returns the message text on hit, "
+                        "or a 'no message' marker on timeout.  Prefer this to busy-polling "
+                        "coop-recv when you're idle between substantive actions."
+                    ),
+                    "inputSchema": {
+                        "type": "object",
+                        "properties": {
+                            "timeout_ms": {
+                                "type": "integer",
+                                "minimum": 100,
+                                "maximum": 30000,
+                                "default": 5000,
+                                "description": "How long to block before giving up.",
+                            }
+                        },
+                    },
+                }
+            ]
+        }
+
+    def _dispatch_tool(self, params: dict[str, Any]) -> dict[str, Any]:
+        name = params.get("name")
+        args = params.get("arguments") or {}
+        if name == "wait_for_message":
+            return self._wait_for_message(args)
+        raise _ToolError(f"unknown tool {name!r}")
+
+    def _wait_for_message(self, args: dict[str, Any]) -> dict[str, Any]:
+        timeout_ms = int(args.get("timeout_ms", 5000))
+        # BLPOP timeout is in seconds (float); clamp to a sane lower
+        # bound so we don't accidentally pass 0 (= block forever).
+        timeout_s = max(0.1, timeout_ms / 1000.0)
+        inbox_key = f"{self._me}:inbox"
+        result = self._r.blpop([inbox_key], timeout=timeout_s)
+        if result is None:
+            return {
+                "content": [{"type": "text", "text": "(no message arrived within the timeout)"}],
+                "isError": False,
+            }
+        _key, raw = result
+        text = raw.decode("utf-8") if isinstance(raw, bytes) else str(raw)
+        return {
+            "content": [{"type": "text", "text": text}],
+            "isError": False,
+        }
+
+
+class _ToolError(Exception):
+    pass
+
+
+def serve_stdio() -> None:  # pragma: no cover -- exercised in e2e
+    """Run the JSON-RPC stdio loop.
+
+    Each line of stdin is one request; each response is one line of
+    stdout.  Notifications produce no output.
+    """
+    server = MCPLongPollServer(
+        redis_client=build_redis_client_from_env(),
+        agent_id=os.environ.get("CB_TEAM_AGENT_ID", "agent"),
+    )
+    for raw in sys.stdin:
+        raw = raw.strip()
+        if not raw:
+            continue
+        try:
+            req = json.loads(raw)
+        except json.JSONDecodeError:
+            continue
+        resp = server.handle(req)
+        if not resp:
+            continue
+        sys.stdout.write(json.dumps(resp) + "\n")
+        sys.stdout.flush()
+
+
+if __name__ == "__main__":  # pragma: no cover
+    serve_stdio()

--- a/src/cooperbench/agents/_team/prompt.py
+++ b/src/cooperbench/agents/_team/prompt.py
@@ -50,16 +50,33 @@ writing code**.  Concretely, at the start of the session:
 2. Create them with `coop-task-create` and assign one per member with
    `coop-task-create --assign <agent> "..."`.
 3. While members work, run `coop-task-list` periodically to watch
-   progress.  If a task is `blocked`, read the `last_note` and either
-   reassign it or unblock it by sending a `coop-send` message.
+   progress.  Files mirror to `/workspace/shared/tasks/` so
+   `ls /workspace/shared/tasks/` and `cat /workspace/shared/tasks/<id>.json`
+   also work without the CLI.  If a task is `blocked`, read the
+   `last_note` and either reassign it or unblock it by sending a
+   `coop-send` message.
 4. When all tasks are `done`, integrate them: read each member's
-   patch under `/workspace/shared/` (members are encouraged to write
-   their diff and notes there), verify the merged tree compiles, and
-   write your final `patch.txt`.
+   patch under `/workspace/shared/<agent>.patch`, merge their work
+   into your working tree, verify the merged tree compiles, and
+   finally **write `/workspace/repo/patch.txt`**.
 
 You **may also pick up tasks yourself** if it would unblock the team
 faster than waiting.  But your default mode is to assign, not
 implement.
+
+### Final submission — REQUIRED
+
+The bench only evaluates `/workspace/repo/patch.txt`.  Files under
+`/workspace/shared/` are coordination artifacts; they are NOT
+evaluated.  Before exiting you MUST run:
+
+```bash
+cd /workspace/repo && git diff > patch.txt && cat patch.txt | head -1
+```
+
+and confirm `patch.txt` is non-empty and contains the merged work of
+the whole team.  If you skip this step, the team's pass rate is 0
+regardless of how well-coordinated the work was.
 
 {_TEAM_LIST_USAGE}
 
@@ -78,15 +95,30 @@ Recommended workflow:
 
 1. Run `coop-task-list --open` to see what needs doing.  If your
    `agent_id` appears as a pre-assigned `owner` on a task, that's the
-   one the lead expects you to take.
+   one the lead expects you to take.  You can also `ls
+   /workspace/shared/tasks/` to browse without the CLI.
 2. `coop-task-claim <task_id>` it.  If you lose the race (exit code 2),
    the task is taken — pick another.
 3. Implement.  When you hit a blocker, run
    `coop-task-update <task_id> blocked -n "<what you need>"` and
    `coop-send {lead} "blocked on task <id>: ..."`.
-4. When done, write your contribution to `/workspace/shared/<your-id>.patch`
-   AND your local `patch.txt`, then
-   `coop-task-update <task_id> done -n "patch at /workspace/shared/<your-id>.patch"`.
+4. When done, copy your diff to `/workspace/shared/<your-id>.patch`
+   (so the lead can find it) AND run the final-submission step below,
+   then `coop-task-update <task_id> done -n "patch at /workspace/shared/<your-id>.patch"`.
+
+### Final submission — REQUIRED
+
+The bench only evaluates `/workspace/repo/patch.txt`.  Files under
+`/workspace/shared/` are coordination artifacts; they are NOT
+evaluated.  Before exiting you MUST run:
+
+```bash
+cd /workspace/repo && git diff > patch.txt && cat patch.txt | head -1
+```
+
+and confirm `patch.txt` is non-empty.  Even if the lead is doing the
+final integration, every member should still write their own
+`patch.txt` — the bench scores per-agent.
 
 {_TEAM_LIST_USAGE}
 

--- a/src/cooperbench/agents/_team/protocol.py
+++ b/src/cooperbench/agents/_team/protocol.py
@@ -1,0 +1,174 @@
+"""Typed request / response protocol layered on plain messaging.
+
+Mirrors Claude Code's ``plan_approval_request`` / ``plan_approval_response``
+shape: a sender posts a typed request with an opaque ``kind`` discriminator,
+the recipient responds, and the sender can await the response by id.
+
+Redis layout (under ``cb:<run_id>:``):
+
+    requests:open:<request_id>    Hash: from, to, kind, body, ts
+    requests:by_recipient:<peer>  Set of open request_ids
+    responses:<request_id>        List the responder pushes to; the
+                                  requester ``BLPOP``s it for ``await_response``
+
+The ``await_response`` API uses ``BLPOP`` so the requester actually
+blocks instead of busy-polling.  ``fetch_response`` is the
+non-blocking equivalent (returns None if no response yet).
+
+Every request and response is also written to the shared task-log
+(``cb:<run_id>:task-log``) so post-run analysis can include
+coordination-protocol events alongside task-list events.
+"""
+
+from __future__ import annotations
+
+import json
+import time
+import uuid
+from typing import Any, Protocol
+
+
+class _RedisLike(Protocol):
+    def hset(self, name: str, key: str | None = None, value: Any = None, mapping: Any = None) -> int: ...
+    def hgetall(self, name: str) -> dict: ...
+    def sadd(self, name: str, *values: Any) -> int: ...
+    def srem(self, name: str, *values: Any) -> int: ...
+    def smembers(self, name: str) -> set: ...
+    def delete(self, *names: str) -> int: ...
+    def rpush(self, name: str, *values: Any) -> int: ...
+    def lrange(self, name: str, start: int, end: int) -> list: ...
+    def lpop(self, name: str, count: int | None = None) -> Any: ...
+    def blpop(self, keys, timeout: float = 0) -> Any: ...
+    def exists(self, *names: str) -> int: ...
+
+
+def _decode(value: Any) -> Any:
+    return value.decode("utf-8") if isinstance(value, bytes) else value
+
+
+def _decode_hash(raw: dict) -> dict:
+    return {_decode(k): _decode(v) for k, v in raw.items()}
+
+
+class ProtocolClient:
+    """Host-side and in-container client for the typed protocol.
+
+    Args:
+        redis_client: ``redis.Redis``-like instance.
+        run_id: bench run id; used as Redis namespace prefix.
+        agent_id: the calling agent's id.  Same client instance is
+            used by both requester and responder roles.
+    """
+
+    def __init__(self, redis_client: _RedisLike, run_id: str, agent_id: str) -> None:
+        self._r = redis_client
+        self._ns = f"cb:{run_id}"
+        self._me = agent_id
+
+    # --- key shape -----------------------------------------------------
+
+    def _req_key(self, rid: str) -> str:
+        return f"{self._ns}:requests:open:{rid}"
+
+    def _inbox_key(self, recipient: str) -> str:
+        return f"{self._ns}:requests:by_recipient:{recipient}"
+
+    def _resp_key(self, rid: str) -> str:
+        return f"{self._ns}:responses:{rid}"
+
+    @property
+    def _log_key(self) -> str:
+        return f"{self._ns}:task-log"
+
+    # --- audit log -----------------------------------------------------
+
+    def _log(self, **event: Any) -> None:
+        event["ts"] = time.time()
+        self._r.rpush(self._log_key, json.dumps(event))
+
+    def log_events(self) -> list[dict[str, Any]]:
+        raw = self._r.lrange(self._log_key, 0, -1)
+        return [json.loads(_decode(e)) for e in raw]
+
+    # --- requester API -------------------------------------------------
+
+    def request(self, *, to: str, kind: str, body: str) -> str:
+        rid = uuid.uuid4().hex[:10]
+        fields = {
+            "id": rid,
+            "from": self._me,
+            "to": to,
+            "kind": kind,
+            "body": body,
+            "ts": str(time.time()),
+        }
+        self._r.hset(self._req_key(rid), mapping=fields)
+        self._r.sadd(self._inbox_key(to), rid)
+        self._log(kind="request", request_id=rid, by=self._me, to=to, request_kind=kind)
+        return rid
+
+    def fetch_response(self, request_id: str) -> dict[str, Any] | None:
+        """Non-blocking read of the response for ``request_id``.
+
+        Returns ``None`` if no response is queued.  Pops the response
+        off the queue (one-shot read).
+        """
+        raw = self._r.lpop(self._resp_key(request_id))
+        if raw is None:
+            return None
+        return json.loads(_decode(raw))
+
+    def await_response(self, request_id: str, timeout: float = 30.0) -> dict[str, Any] | None:
+        """Block until a response arrives or ``timeout`` seconds pass.
+
+        Backed by ``BLPOP`` so the caller actually sleeps instead of
+        busy-polling.  Returns the response dict, or ``None`` on timeout.
+        """
+        # BLPOP returns (key, value) on hit, None on timeout.  Redis
+        # uses 0 to mean "block forever"; we forbid that by clamping.
+        clamped = max(0.05, float(timeout))
+        result = self._r.blpop([self._resp_key(request_id)], timeout=clamped)
+        if result is None:
+            return None
+        _key, raw = result
+        return json.loads(_decode(raw))
+
+    # --- responder API -------------------------------------------------
+
+    def list_pending(self) -> list[dict[str, Any]]:
+        """All open requests addressed to this agent."""
+        ids = sorted(_decode(m) for m in self._r.smembers(self._inbox_key(self._me)))
+        out = []
+        for rid in ids:
+            raw = _decode_hash(self._r.hgetall(self._req_key(rid)))
+            if not raw:
+                continue
+            try:
+                raw["ts"] = float(raw["ts"])
+            except (KeyError, ValueError):
+                pass
+            out.append(raw)
+        return out
+
+    def respond(self, *, request_id: str, body: str) -> None:
+        """Send a response to an open request.
+
+        Raises ``KeyError`` if the request_id is unknown / already
+        responded to / wasn't addressed to this agent.
+        """
+        if not self._r.exists(self._req_key(request_id)):
+            raise KeyError(request_id)
+        req = _decode_hash(self._r.hgetall(self._req_key(request_id)))
+        if req.get("to") != self._me:
+            raise KeyError(f"request {request_id} not addressed to {self._me}")
+        response = {
+            "id": request_id,
+            "from": self._me,
+            "to": req.get("from"),
+            "body": body,
+            "ts": time.time(),
+        }
+        self._r.rpush(self._resp_key(request_id), json.dumps(response))
+        self._r.delete(self._req_key(request_id))
+        self._r.srem(self._inbox_key(self._me), request_id)
+        self._log(kind="response", request_id=request_id, by=self._me, to=req.get("from"))

--- a/src/cooperbench/agents/_team/runtime.py
+++ b/src/cooperbench/agents/_team/runtime.py
@@ -10,6 +10,9 @@ from __future__ import annotations
 CONTAINER_SCRATCHPAD_DIR = "/workspace/shared"
 """Where the team scratchpad volume is mounted inside every container."""
 
+CONTAINER_TASKS_MIRROR_DIR = f"{CONTAINER_SCRATCHPAD_DIR}/tasks"
+"""Filesystem mirror of the task list, populated by ``coop-task-list``."""
+
 
 def build_team_env(
     *,
@@ -29,6 +32,7 @@ def build_team_env(
         "CB_TEAM_RUN_ID": run_id,
         "CB_TEAM_AGENT_ID": agent_id,
         "CB_TEAM_AGENTS": ",".join(agents),
+        "CB_TEAM_TASKS_DIR": CONTAINER_TASKS_MIRROR_DIR,
     }
     if team_role:
         env["CB_TEAM_ROLE"] = team_role

--- a/src/cooperbench/agents/claude_code/adapter.py
+++ b/src/cooperbench/agents/claude_code/adapter.py
@@ -55,8 +55,10 @@ COOP_MSG_SCRIPT_PATH = _PACKAGE_DIR.parent / "_coop" / "coop_msg.py"
 COOP_INSTALL_SNIPPET_PATH = _PACKAGE_DIR.parent / "_coop" / "install_snippet.sh"
 TEAM_TASK_SCRIPT_PATH = _PACKAGE_DIR.parent / "_team" / "coop_task.py"
 TEAM_INSTALL_SNIPPET_PATH = _PACKAGE_DIR.parent / "_team" / "install_snippet.sh"
+TEAM_MCP_SCRIPT_PATH = _PACKAGE_DIR.parent / "_team" / "mcp_server.py"
 CONTAINER_TEAM_TASK_PATH = "/tmp/cb-coop-task.py"
 CONTAINER_TEAM_INSTALL_PATH = "/tmp/cb-team-install.sh"
+CONTAINER_TEAM_MCP_PATH = "/tmp/cb-mcp-server.py"
 
 # Inside the container, we redirect Claude Code's per-session state under
 # /tmp so we always know where to find the JSONL trajectory after the run.
@@ -286,6 +288,27 @@ class ClaudeCodeRunner:
             if team_task_source is not None:
                 write_file_in_container(env, CONTAINER_TEAM_TASK_PATH, team_task_source)
                 write_file_in_container(env, CONTAINER_TEAM_INSTALL_PATH, TEAM_INSTALL_SNIPPET_PATH.read_text())
+                # MCP long-poll server: copy the script + register it in
+                # ~/.claude.json so the CLI knows about wait_for_message.
+                write_file_in_container(env, CONTAINER_TEAM_MCP_PATH, TEAM_MCP_SCRIPT_PATH.read_text())
+                mcp_config = {
+                    "mcpServers": {
+                        "cooperbench-team": {
+                            "type": "stdio",
+                            "command": "python3",
+                            "args": [CONTAINER_TEAM_MCP_PATH],
+                        }
+                    }
+                }
+                env.execute(
+                    {"command": f"mkdir -p {shlex.quote(CONTAINER_CLAUDE_CONFIG_DIR)}"},
+                    timeout=30,
+                )
+                write_file_in_container(
+                    env,
+                    f"{CONTAINER_CLAUDE_CONFIG_DIR}/.claude.json",
+                    json.dumps(mcp_config, indent=2),
+                )
 
             # 2. Install claude-code in the container.
             write_file_in_container(env, CONTAINER_SETUP_PATH, setup_script)

--- a/src/cooperbench/agents/codex/adapter.py
+++ b/src/cooperbench/agents/codex/adapter.py
@@ -54,8 +54,10 @@ COOP_MSG_SCRIPT_PATH = _PACKAGE_DIR.parent / "_coop" / "coop_msg.py"
 COOP_INSTALL_SNIPPET_PATH = _PACKAGE_DIR.parent / "_coop" / "install_snippet.sh"
 TEAM_TASK_SCRIPT_PATH = _PACKAGE_DIR.parent / "_team" / "coop_task.py"
 TEAM_INSTALL_SNIPPET_PATH = _PACKAGE_DIR.parent / "_team" / "install_snippet.sh"
+TEAM_MCP_SCRIPT_PATH = _PACKAGE_DIR.parent / "_team" / "mcp_server.py"
 CONTAINER_TEAM_TASK_PATH = "/tmp/cb-coop-task.py"
 CONTAINER_TEAM_INSTALL_PATH = "/tmp/cb-team-install.sh"
+CONTAINER_TEAM_MCP_PATH = "/tmp/cb-mcp-server.py"
 
 CONTAINER_CODEX_HOME = "/tmp/codex-home"
 CONTAINER_AUTH_PATH = f"{CONTAINER_CODEX_HOME}/auth.json"
@@ -243,6 +245,20 @@ class CodexRunner:
             if team_task_source is not None:
                 write_file_in_container(env, CONTAINER_TEAM_TASK_PATH, team_task_source)
                 write_file_in_container(env, CONTAINER_TEAM_INSTALL_PATH, TEAM_INSTALL_SNIPPET_PATH.read_text())
+                # MCP long-poll server: copy + register in Codex's TOML config.
+                write_file_in_container(env, CONTAINER_TEAM_MCP_PATH, TEAM_MCP_SCRIPT_PATH.read_text())
+                env.execute(
+                    {"command": f"mkdir -p {shlex.quote(CONTAINER_CODEX_HOME)}"},
+                    timeout=30,
+                )
+                # Codex's MCP config lives in config.toml.  We keep it
+                # tiny (one server entry) since the file may not exist
+                # yet — Codex tolerates a fresh config that *only*
+                # contains mcpServers.
+                toml_body = (
+                    f'[mcp_servers.cooperbench-team]\ncommand = "python3"\nargs = ["{CONTAINER_TEAM_MCP_PATH}"]\n'
+                )
+                write_file_in_container(env, f"{CONTAINER_CODEX_HOME}/config.toml", toml_body)
 
             # 2. Install codex in the container.
             write_file_in_container(env, CONTAINER_SETUP_PATH, setup_script)

--- a/src/cooperbench/agents/mini_swe_agent_v2/adapter.py
+++ b/src/cooperbench/agents/mini_swe_agent_v2/adapter.py
@@ -47,14 +47,21 @@ class MiniSweAgentV2Runner:
     ) -> AgentResult:
         """Run mini-swe-agent v2 on a task.
 
-        Team-mode kwargs (``team_role``, ``team_id``, ``task_list_url``)
-        are accepted so the adapter is API-compatible with the team
-        runner, but their effect today is limited: the prompt switches
-        to the team-mode block via ``build_team_instruction`` so the
-        agent learns about the ``coop-task-*`` CLI, but the in-loop
-        auto-refresh hook lands in a follow-up PR.
+        When team-mode kwargs (``team_role``, ``team_id``,
+        ``task_list_url``) are set, the adapter attaches a
+        ``TeamPoller`` to the agent so each ``step()`` injects a fresh
+        team-task-list summary as a user message before the LLM call —
+        the same shape as the existing inbox-poll hook.
         """
-        del team_role, team_id, task_list_url  # see docstring
+        team_poller = None
+        if team_role and team_id and task_list_url and agents and len(agents) > 1:
+            from cooperbench.agents._team import TeamPoller
+
+            team_poller = TeamPoller(
+                redis_url=task_list_url,
+                run_id=team_id,
+                agent_id=agent_id,
+            )
         # Load coop config when multiple agents, otherwise solo config.
         is_coop = bool(agents) and len(agents) > 1
         config_name = "coop" if is_coop else "solo"
@@ -143,6 +150,10 @@ class MiniSweAgentV2Runner:
             **agent_cfg,
         )
         agent.extra_template_vars.update(extra_vars)
+        # Auto-refresh of the shared task list between LLM calls when
+        # team mode is active.  step() picks this up as ``agent.team_poller``.
+        if team_poller is not None:
+            agent.team_poller = team_poller
 
         # Run agent
         error_msg = None

--- a/src/cooperbench/agents/mini_swe_agent_v2/agents/default.py
+++ b/src/cooperbench/agents/mini_swe_agent_v2/agents/default.py
@@ -133,7 +133,8 @@ class DefaultAgent:
         return self.messages[-1].get("extra", {})
 
     def step(self) -> list[dict]:
-        """Query the LM, execute actions. Polls for inter-agent messages before querying."""
+        """Query the LM, execute actions. Polls for inter-agent messages
+        and (in team mode) the shared task list before querying."""
         # Check for inter-agent messages before querying LLM
         if self.comm:
             messages = self.comm.receive()
@@ -146,6 +147,15 @@ class DefaultAgent:
                         content=f"[Message from {msg['from']}]: {msg['content']}",
                     )
                 )
+        # In team mode, also refresh the shared task list so the LLM
+        # sees the live state of who's working on what before its next
+        # response.  ``team_poller`` is set by the adapter when team
+        # kwargs are present; absent for solo/coop.
+        poller = getattr(self, "team_poller", None)
+        if poller is not None:
+            summary = poller.poll()
+            if summary:
+                self.add_messages(self.model.format_message(role="user", content=summary))
         return self.execute_actions(self.query())
 
     def _get_prompt_tokens(self, message: dict) -> int:

--- a/src/cooperbench/runner/core.py
+++ b/src/cooperbench/runner/core.py
@@ -364,13 +364,20 @@ def _print_single_result(result: dict, task: dict, is_solo: bool) -> None:
         for agent_id, r in result.get("results", {}).items():
             status = r.get("status", "Error")
             status_style = "green" if status == "Submitted" else "red"
+            # Team-mode per-agent dicts store ``patch_lines`` (an int);
+            # coop's store the full ``patch`` (a string).  Accept either
+            # so this display works for both.
+            if "patch_lines" in r:
+                lines_str = str(r["patch_lines"])
+            else:
+                lines_str = str(len(r.get("patch", "").splitlines()))
             table.add_row(
                 agent_id,
                 str(r.get("feature_id", "?")),
                 f"[{status_style}]{status}[/{status_style}]",
                 f"${r.get('cost', 0):.2f}",
                 str(r.get("steps", 0)),
-                str(len(r.get("patch", "").splitlines())),
+                lines_str,
             )
 
     console.print(table)

--- a/tests/agents/_team/test_fs_mirror.py
+++ b/tests/agents/_team/test_fs_mirror.py
@@ -1,0 +1,121 @@
+"""Unit tests for the filesystem mirror of the task list.
+
+Claude Code's team primitive stores tasks as on-disk JSON files so
+agents can ``ls``/``cat``/``grep`` them with their existing tools — no
+new tool surface to learn.  We mirror that for CooperBench by
+snapshotting the Redis task list to ``/workspace/shared/tasks/`` on
+every ``coop-task-list`` invocation.
+
+Layout (all under ``CONTAINER_SCRATCHPAD_DIR/tasks/``):
+
+    <task_id>.json       one file per task, fields mirror TaskListClient.get()
+    _index.json          {"updated_at": <ts>, "ids": [...]}; cheap directory listing
+                         agents can grep without opening every file
+    _log.jsonl           audit log copy (one JSON event per line)
+
+The mirror is *eventually consistent* — there's no inotify-style push
+from Redis, just a snapshot every time something runs ``coop-task-list``.
+That's fine for our cadence; the bench is built around agents that
+poll between turns anyway.
+"""
+
+from __future__ import annotations
+
+import json
+
+import fakeredis
+import pytest
+
+from cooperbench.agents._team.fs_mirror import mirror_to_directory
+from cooperbench.agents._team.task_list import TaskListClient
+
+
+@pytest.fixture
+def client():
+    fake = fakeredis.FakeRedis()
+    return TaskListClient(redis_client=fake, run_id="test")
+
+
+@pytest.fixture
+def mirror_dir(tmp_path):
+    target = tmp_path / "shared" / "tasks"
+    return target
+
+
+class TestMirrorToDirectory:
+    def test_creates_one_file_per_task(self, client, mirror_dir):
+        a = client.create(title="a", created_by="lead")
+        b = client.create(title="b", created_by="lead")
+        mirror_to_directory(client, mirror_dir)
+        files = sorted(p.name for p in mirror_dir.iterdir() if p.suffix == ".json" and not p.name.startswith("_"))
+        assert files == sorted([f"{a}.json", f"{b}.json"])
+
+    def test_file_contents_match_task(self, client, mirror_dir):
+        task_id = client.create(title="hello", created_by="lead", owner="agent2")
+        mirror_to_directory(client, mirror_dir)
+        data = json.loads((mirror_dir / f"{task_id}.json").read_text())
+        assert data["id"] == task_id
+        assert data["title"] == "hello"
+        assert data["owner"] == "agent2"
+        assert data["status"] == "open"
+
+    def test_writes_index_file(self, client, mirror_dir):
+        ids = [client.create(title=f"t{i}", created_by="lead") for i in range(3)]
+        mirror_to_directory(client, mirror_dir)
+        index = json.loads((mirror_dir / "_index.json").read_text())
+        assert sorted(index["ids"]) == sorted(ids)
+        assert "updated_at" in index
+        assert isinstance(index["updated_at"], float)
+
+    def test_writes_log_jsonl(self, client, mirror_dir):
+        task_id = client.create(title="t", created_by="lead")
+        client.claim(task_id, by="agent2")
+        mirror_to_directory(client, mirror_dir)
+        log_lines = (mirror_dir / "_log.jsonl").read_text().splitlines()
+        assert len(log_lines) == 2  # create + claim
+        # Each line is valid JSON.
+        for line in log_lines:
+            json.loads(line)
+
+    def test_removes_stale_files(self, client, mirror_dir):
+        a = client.create(title="a", created_by="lead")
+        mirror_to_directory(client, mirror_dir)
+        # Now delete the underlying task and mirror again — the file
+        # for `a` should disappear.
+        client._r.delete(client._task_key(a))
+        client._r.srem(client._all_key, a)
+        mirror_to_directory(client, mirror_dir)
+        assert not (mirror_dir / f"{a}.json").exists()
+
+    def test_directory_created_if_missing(self, client, tmp_path):
+        target = tmp_path / "does" / "not" / "exist" / "tasks"
+        client.create(title="t", created_by="lead")
+        mirror_to_directory(client, target)
+        assert target.exists()
+        assert (target / "_index.json").exists()
+
+    def test_empty_list_still_writes_index(self, client, mirror_dir):
+        mirror_to_directory(client, mirror_dir)
+        index = json.loads((mirror_dir / "_index.json").read_text())
+        assert index["ids"] == []
+
+    def test_subsequent_mirrors_are_atomic_per_file(self, client, mirror_dir):
+        """A reader watching ``_index.json`` must always see a consistent view.
+
+        We don't get atomic dirsync, but we do guarantee each file is
+        written as a single ``write_text`` (Python's tempfile+replace
+        idiom under the hood) — so a reader either sees the old or new
+        version of a given file, never a half-written one.
+        """
+        task_id = client.create(title="initial", created_by="lead")
+        mirror_to_directory(client, mirror_dir)
+        # Mutate and re-mirror.  We use ``claim`` to change owner +
+        # status and ``update`` to add a note — both real writes.
+        client.claim(task_id, by="agent1")
+        client.update(task_id, by="agent1", status="in_progress", note="started")
+        mirror_to_directory(client, mirror_dir)
+        contents = (mirror_dir / f"{task_id}.json").read_text()
+        assert contents.strip(), "file must never be empty after a successful mirror"
+        data = json.loads(contents)
+        assert data["owner"] == "agent1"
+        assert data["last_note"] == "started"

--- a/tests/agents/_team/test_loop_refresh.py
+++ b/tests/agents/_team/test_loop_refresh.py
@@ -1,0 +1,116 @@
+"""Unit tests for the in-loop task-list refresh helper.
+
+Python-loop adapters (mini_swe_agent_v2, swe_agent, openhands_sdk)
+poll their inbox between steps.  When team mode is active they should
+*also* refresh the task list and inject a summary as a user message so
+the LLM sees the current state of the shared list before its next
+response — without needing to remember to call ``coop-task-list``.
+
+``format_task_summary`` and ``poll_team_state`` are pure helpers that
+the adapters' existing inbox-check hooks call when ``CB_TEAM_REDIS_URL``
++ ``CB_TEAM_AGENT_ID`` are present in the env.  They return plain
+strings the adapter prepends to the conversation; the adapter does
+the actual ``add_messages`` call so we don't have to know each
+framework's message shape.
+"""
+
+from __future__ import annotations
+
+import fakeredis
+import pytest
+
+from cooperbench.agents._team.loop_refresh import (
+    TeamPoller,
+    format_task_summary,
+    poll_team_state,
+)
+from cooperbench.agents._team.task_list import TaskListClient
+
+
+@pytest.fixture
+def shared():
+    fake = fakeredis.FakeRedis()
+    client = TaskListClient(redis_client=fake, run_id="t")
+    return fake, client
+
+
+class TestFormatTaskSummary:
+    def test_summary_groups_by_status(self):
+        tasks = [
+            {"id": "t1", "title": "alpha", "status": "open", "owner": ""},
+            {"id": "t2", "title": "beta", "status": "in_progress", "owner": "agent1"},
+            {"id": "t3", "title": "gamma", "status": "done", "owner": "agent2"},
+        ]
+        text = format_task_summary(tasks, viewer="agent1")
+        # Status counts surface up top so the LLM sees the headline first.
+        assert "open: 1" in text
+        assert "in_progress: 1" in text
+        assert "done: 1" in text
+        # Each task is mentioned by title.
+        assert "alpha" in text
+        assert "beta" in text
+        assert "gamma" in text
+
+    def test_summary_calls_out_viewer_tasks(self):
+        tasks = [
+            {"id": "t1", "title": "mine", "status": "in_progress", "owner": "agent1"},
+            {"id": "t2", "title": "theirs", "status": "in_progress", "owner": "agent2"},
+        ]
+        text = format_task_summary(tasks, viewer="agent1")
+        # The viewer's own task should be clearly marked.
+        assert "your task" in text.lower() or "you own" in text.lower()
+
+    def test_empty_summary_is_concise(self):
+        text = format_task_summary([], viewer="agent1")
+        assert "no tasks" in text.lower()
+        assert len(text) < 200  # don't waste tokens on an empty state
+
+
+class TestPollTeamState:
+    def test_returns_none_when_env_missing(self, monkeypatch):
+        monkeypatch.delenv("CB_TEAM_REDIS_URL", raising=False)
+        assert poll_team_state() is None
+
+    def test_returns_none_when_redis_unreachable(self, monkeypatch):
+        monkeypatch.setenv("CB_TEAM_REDIS_URL", "redis://localhost:1")  # unreachable
+        monkeypatch.setenv("CB_TEAM_RUN_ID", "t")
+        monkeypatch.setenv("CB_TEAM_AGENT_ID", "agent1")
+        # Should swallow connection errors and return None — never
+        # crash the agent loop because Redis is down.
+        assert poll_team_state() is None
+
+    def test_returns_summary_string_when_reachable(self, monkeypatch, shared):
+        fake, client = shared
+        client.create(title="t1", created_by="lead", owner="agent1")
+        monkeypatch.setenv("CB_TEAM_REDIS_URL", "redis://stub")
+        monkeypatch.setenv("CB_TEAM_RUN_ID", "t")
+        monkeypatch.setenv("CB_TEAM_AGENT_ID", "agent1")
+
+        # Patch the redis client factory so we use fakeredis.
+        from unittest.mock import patch as mp
+
+        with mp("cooperbench.agents._team.loop_refresh._client_from_env", return_value=fake):
+            summary = poll_team_state()
+
+        assert summary is not None
+        assert "t1" in summary
+
+
+class TestTeamPoller:
+    """Host-side per-agent poller used by Python-loop adapters."""
+
+    def test_poll_returns_summary_when_reachable(self, shared):
+        fake, client = shared
+        task_id = client.create(title="hello", created_by="lead", owner="agent1")
+        poller = TeamPoller(redis_url="redis://stub", run_id="t", agent_id="agent1")
+        poller._client = fake  # inject fakeredis directly
+        summary = poller.poll()
+        assert summary is not None
+        assert task_id in summary
+        assert "hello" in summary
+
+    def test_poll_returns_none_when_unreachable(self):
+        poller = TeamPoller(redis_url="redis://localhost:1", run_id="t", agent_id="agent1")
+        # Don't pre-set _client; ensure_client should fail at connect-time
+        # and poll should swallow the error.
+        assert poller.poll() is None

--- a/tests/agents/_team/test_mcp_server.py
+++ b/tests/agents/_team/test_mcp_server.py
@@ -1,0 +1,161 @@
+"""Unit tests for the MCP long-poll server.
+
+CLI adapters (Claude Code, Codex) run an opaque LLM loop, so we can't
+inject inbox messages between their turns the way Python-loop adapters
+can.  The next-best thing is to give them a long-poll tool that
+*blocks server-side* until a message arrives, so "watch the inbox"
+becomes a natural idle behavior instead of a busy-loop on
+``coop-recv``.
+
+The server speaks the MCP JSON-RPC handshake over stdio.  Only three
+methods matter for our use:
+
+  - ``initialize``        — handshake; server reports capabilities.
+  - ``tools/list``        — advertises the ``wait_for_message`` tool.
+  - ``tools/call``        — executes the tool (BLPOPs the inbox).
+
+These tests drive the server in-process by feeding it ``dict`` requests
+and asserting on the response dicts.  Real Claude Code / Codex
+integration is covered by the end-to-end run.
+"""
+
+from __future__ import annotations
+
+import threading
+import time
+
+import fakeredis
+import pytest
+
+from cooperbench.agents._team.mcp_server import (
+    MCPLongPollServer,
+    build_redis_client_from_env,
+)
+
+
+@pytest.fixture
+def shared_redis():
+    return fakeredis.FakeRedis()
+
+
+@pytest.fixture
+def server(shared_redis, monkeypatch):
+    monkeypatch.setenv("CB_TEAM_REDIS_URL", "redis://stub")
+    monkeypatch.setenv("CB_TEAM_AGENT_ID", "agent1")
+    return MCPLongPollServer(redis_client=shared_redis, agent_id="agent1")
+
+
+class TestInitialize:
+    def test_initialize_returns_protocol_version_and_capabilities(self, server):
+        resp = server.handle(
+            {
+                "jsonrpc": "2.0",
+                "id": 1,
+                "method": "initialize",
+                "params": {"protocolVersion": "2025-06-18"},
+            }
+        )
+        assert resp["id"] == 1
+        assert "result" in resp
+        result = resp["result"]
+        assert "protocolVersion" in result
+        assert "capabilities" in result
+        # We expose tools.
+        assert "tools" in result["capabilities"]
+
+    def test_initialize_includes_server_info(self, server):
+        resp = server.handle({"jsonrpc": "2.0", "id": 1, "method": "initialize", "params": {}})
+        assert resp["result"]["serverInfo"]["name"]
+
+
+class TestToolsList:
+    def test_advertises_wait_for_message(self, server):
+        resp = server.handle({"jsonrpc": "2.0", "id": 2, "method": "tools/list", "params": {}})
+        tools = resp["result"]["tools"]
+        names = [t["name"] for t in tools]
+        assert "wait_for_message" in names
+        wait = next(t for t in tools if t["name"] == "wait_for_message")
+        # Schema declares the timeout_ms input.
+        assert "inputSchema" in wait
+        assert "timeout_ms" in wait["inputSchema"]["properties"]
+
+
+class TestToolsCall:
+    def test_returns_message_when_one_arrives(self, server, shared_redis):
+        # Push a message into our inbox.
+        shared_redis.rpush("agent1:inbox", '{"from": "bob", "content": "hello"}')
+        resp = server.handle(
+            {
+                "jsonrpc": "2.0",
+                "id": 3,
+                "method": "tools/call",
+                "params": {"name": "wait_for_message", "arguments": {"timeout_ms": 100}},
+            }
+        )
+        text = resp["result"]["content"][0]["text"]
+        assert "bob" in text
+        assert "hello" in text
+
+    def test_returns_empty_on_timeout(self, server):
+        resp = server.handle(
+            {
+                "jsonrpc": "2.0",
+                "id": 4,
+                "method": "tools/call",
+                "params": {"name": "wait_for_message", "arguments": {"timeout_ms": 100}},
+            }
+        )
+        # Should not error; should indicate timeout.
+        text = resp["result"]["content"][0]["text"]
+        assert "no message" in text.lower() or "timeout" in text.lower()
+
+    def test_blocks_until_message_arrives(self, server, shared_redis):
+        """Server-side blocking is the whole point of this tool."""
+
+        def _delayed_push():
+            time.sleep(0.05)
+            shared_redis.rpush("agent1:inbox", '{"from": "bob", "content": "late"}')
+
+        t = threading.Thread(target=_delayed_push)
+        t.start()
+        start = time.time()
+        resp = server.handle(
+            {
+                "jsonrpc": "2.0",
+                "id": 5,
+                "method": "tools/call",
+                "params": {"name": "wait_for_message", "arguments": {"timeout_ms": 2000}},
+            }
+        )
+        t.join()
+        elapsed = time.time() - start
+        # Should have actually blocked for some non-zero time (we
+        # injected at +50ms).
+        assert elapsed >= 0.04
+        text = resp["result"]["content"][0]["text"]
+        assert "late" in text
+
+    def test_unknown_tool_returns_error(self, server):
+        resp = server.handle(
+            {
+                "jsonrpc": "2.0",
+                "id": 6,
+                "method": "tools/call",
+                "params": {"name": "made_up_tool", "arguments": {}},
+            }
+        )
+        assert "error" in resp
+
+
+class TestEnvFactory:
+    def test_factory_reads_env(self, monkeypatch):
+        monkeypatch.setenv("CB_TEAM_REDIS_URL", "redis://x:6379#run:abc")
+        client = build_redis_client_from_env()
+        # We can't really probe a real client; just make sure it
+        # returned something with the redis interface.
+        assert hasattr(client, "blpop")
+
+    def test_factory_raises_when_env_missing(self, monkeypatch):
+        monkeypatch.delenv("CB_TEAM_REDIS_URL", raising=False)
+        with pytest.raises(RuntimeError):
+            build_redis_client_from_env()

--- a/tests/agents/_team/test_prompt.py
+++ b/tests/agents/_team/test_prompt.py
@@ -132,6 +132,48 @@ class TestSoloFallback:
         assert "coop-task" not in text
 
 
+class TestFinalSubmissionExplicit:
+    """Regression test for the e2e finding where members wrote diffs
+    only to the scratchpad and never to ``patch.txt``."""
+
+    def test_lead_prompt_demands_patch_txt(self):
+        text = build_team_instruction(
+            task="t",
+            agents=["agent1", "agent2"],
+            agent_id="agent1",
+            team_role="lead",
+            git_enabled=False,
+        )
+        assert "patch.txt" in text
+        assert "REQUIRED" in text or "MUST" in text
+        assert "/workspace/repo/patch.txt" in text
+
+    def test_member_prompt_demands_patch_txt(self):
+        text = build_team_instruction(
+            task="t",
+            agents=["agent1", "agent2"],
+            agent_id="agent2",
+            team_role="member",
+            git_enabled=False,
+        )
+        assert "/workspace/repo/patch.txt" in text
+        assert "git diff > patch.txt" in text
+
+    def test_both_prompts_call_out_shared_not_evaluated(self):
+        for role in ("lead", "member"):
+            text = build_team_instruction(
+                task="t",
+                agents=["agent1", "agent2"],
+                agent_id="agent1" if role == "lead" else "agent2",
+                team_role=role,
+                git_enabled=False,
+            )
+            # The whole point of the fix: tell the agent shared/ is
+            # coordination, not submission.
+            assert "/workspace/shared" in text
+            assert "NOT" in text or "not evaluated" in text.lower()
+
+
 class TestGitInteraction:
     def test_git_block_appended_when_enabled(self):
         text = build_team_instruction(

--- a/tests/agents/_team/test_protocol.py
+++ b/tests/agents/_team/test_protocol.py
@@ -1,0 +1,124 @@
+"""Unit tests for the typed coop-request / coop-respond protocol.
+
+Layered on top of plain ``coop-send`` messaging.  Mirrors Claude Code's
+``plan_approval_request`` / ``plan_approval_response`` shape:
+
+  - ``request(peer, kind, body) -> request_id`` queues a request in the
+    peer's inbox AND records it in ``cb:<run>:requests:open:<id>`` so
+    the responder has a known target to write back to.
+  - ``respond(request_id, body)`` writes to
+    ``cb:<run>:responses:<id>`` and deletes the open entry.
+  - ``await_response(request_id, timeout)`` blocks (BLPOP-style) until
+    a response shows up or the timeout fires.
+
+The host-side ``ProtocolClient`` is the testable seam (we use
+``fakeredis``); the in-container CLI just wraps it.
+"""
+
+from __future__ import annotations
+
+import threading
+import time
+
+import fakeredis
+import pytest
+
+from cooperbench.agents._team.protocol import ProtocolClient
+
+
+@pytest.fixture
+def shared_redis():
+    return fakeredis.FakeRedis()
+
+
+@pytest.fixture
+def alice(shared_redis):
+    return ProtocolClient(redis_client=shared_redis, run_id="t", agent_id="alice")
+
+
+@pytest.fixture
+def bob(shared_redis):
+    return ProtocolClient(redis_client=shared_redis, run_id="t", agent_id="bob")
+
+
+class TestRequest:
+    def test_request_returns_id(self, alice, bob):
+        rid = alice.request(to="bob", kind="approval", body="ok to proceed?")
+        assert rid
+        assert isinstance(rid, str)
+        # Bob can see one open request addressed to him.
+        pending = bob.list_pending()
+        assert len(pending) == 1
+        assert pending[0]["id"] == rid
+        assert pending[0]["from"] == "alice"
+        assert pending[0]["kind"] == "approval"
+        assert pending[0]["body"] == "ok to proceed?"
+
+    def test_response_round_trips(self, alice, bob):
+        rid = alice.request(to="bob", kind="approval", body="?")
+        bob.respond(request_id=rid, body="approved")
+        # Alice should be able to fetch it without blocking.
+        resp = alice.fetch_response(rid)
+        assert resp is not None
+        assert resp["from"] == "bob"
+        assert resp["body"] == "approved"
+
+    def test_respond_clears_pending(self, alice, bob):
+        rid = alice.request(to="bob", kind="approval", body="?")
+        bob.respond(request_id=rid, body="ok")
+        assert bob.list_pending() == []
+
+    def test_fetch_response_missing_returns_none(self, alice):
+        assert alice.fetch_response("nonexistent") is None
+
+    def test_respond_to_unknown_request_raises(self, bob):
+        with pytest.raises(KeyError):
+            bob.respond(request_id="nope", body="ok")
+
+
+class TestAwait:
+    def test_await_response_returns_when_responded(self, alice, bob):
+        rid = alice.request(to="bob", kind="approval", body="?")
+
+        # Have a thread respond after a short delay so the blocking call
+        # actually has to wait.
+        def _delayed_respond():
+            time.sleep(0.05)
+            bob.respond(request_id=rid, body="approved")
+
+        t = threading.Thread(target=_delayed_respond)
+        t.start()
+
+        resp = alice.await_response(rid, timeout=2.0)
+        t.join()
+
+        assert resp is not None
+        assert resp["body"] == "approved"
+
+    def test_await_response_times_out(self, alice, bob):
+        rid = alice.request(to="bob", kind="approval", body="?")
+        start = time.time()
+        resp = alice.await_response(rid, timeout=0.3)
+        elapsed = time.time() - start
+        assert resp is None
+        # Timed out (allow generous slack — fakeredis behaviour varies).
+        assert elapsed >= 0.25
+
+
+class TestAuditLog:
+    """Every request and response is appended to the task-log so the
+    bench can count them post-run."""
+
+    def test_request_logged(self, alice, bob):
+        alice.request(to="bob", kind="approval", body="?")
+        events = alice.log_events()
+        kinds = [e.get("kind") for e in events]
+        assert "request" in kinds
+
+    def test_response_logged(self, alice, bob):
+        rid = alice.request(to="bob", kind="approval", body="?")
+        bob.respond(request_id=rid, body="ok")
+        events = alice.log_events()
+        kinds = [e.get("kind") for e in events]
+        assert "request" in kinds
+        assert "response" in kinds

--- a/tests/agents/_team/test_runtime.py
+++ b/tests/agents/_team/test_runtime.py
@@ -7,6 +7,7 @@ arg list (scratchpad mount).
 
 from cooperbench.agents._team.runtime import (
     CONTAINER_SCRATCHPAD_DIR,
+    CONTAINER_TASKS_MIRROR_DIR,
     build_team_env,
     scratchpad_mount_args,
 )
@@ -26,6 +27,8 @@ class TestBuildTeamEnv:
         assert env["CB_TEAM_AGENT_ID"] == "agent1"
         assert env["CB_TEAM_AGENTS"] == "agent1,agent2"
         assert env["CB_TEAM_ROLE"] == "lead"
+        # Tasks mirror dir auto-set so coop-task-list can snapshot to disk.
+        assert env["CB_TEAM_TASKS_DIR"] == CONTAINER_TASKS_MIRROR_DIR
 
     def test_missing_role_omitted_not_empty(self):
         """Empty values would cause the CLI to think it has a role."""


### PR DESCRIPTION
## Summary

Lands the four follow-ups called out as "Out of scope" on the team-mode PR (#52), plus a prompt fix surfaced by that PR's end-to-end run.

1. **Filesystem mirror of task list** (`_team/fs_mirror.py`) — snapshots Redis state to `/workspace/shared/tasks/<id>.json` + `_index.json` + `_log.jsonl` so agents can `ls`/`cat` tasks with their existing tools.  Mirrors CC's team primitive.  Atomic per-file writes via tempfile+replace.
2. **Typed `coop-request` / `coop-respond` protocol** (`_team/protocol.py`) — request/response with ID echo, mirroring CC's `plan_approval_request` shape.  Sender's `await_response` uses BLPOP so it actually sleeps.  Both events flow into the shared task-log.
3. **MCP long-poll server** (`_team/mcp_server.py`) — stdio JSON-RPC server exposing `wait_for_message`, backed by BLPOP on the agent's inbox.  Registered in `~/.claude.json` (Claude Code) and `~/.codex/config.toml` (Codex).  Closest we can get to push delivery for opaque CLI agent loops.
4. **In-loop task-list auto-refresh** (`_team/loop_refresh.py`) — `TeamPoller` injects a compact `[Team task list] open: 1, in_progress: 2 ...` summary as a user message before every `mini_swe_agent_v2.step()` (same hook as the existing inbox poll).  The LLM sees current state without remembering to call `coop-task-list`.
5. **Prompt fix** — the previous team-mode e2e had members writing diffs to scratchpad only, scoring 0/2.  Both lead and member prompts now include an explicit `### Final submission — REQUIRED` section calling out `patch.txt` as the only file the bench evaluates.

Cosmetic fix to `runner/core._print_single_result` so team-mode per-agent dicts (which carry `patch_lines: int`) render correctly — previously the column showed 0.

Stacks on #52.

## Tests

**37 new unit tests, all hermetic (fakeredis):**

| Module | Coverage |
| --- | --- |
| `test_fs_mirror.py` (8) | atomic writes, stale cleanup, empty-index case, deep mkdir |
| `test_protocol.py` (9) | request roundtrip, BLPOP await, timeout, audit log |
| `test_mcp_server.py` (9) | initialize, tools/list, tools/call, blocking, unknown-tool, env factory |
| `test_loop_refresh.py` (8) | summary formatting, TeamPoller, env-driven `poll_team_state` |
| `test_prompt.py` (+3) | regression: lead+member prompts demand `patch.txt` |

**Full suite: 311 passed, 63 skipped.**  Ruff / format / mypy all green.

## End-to-end

Same task as the team-mode PR (`dottxt_ai_outlines_task/1371 [1,2]`) with Claude Code in team+git mode:

**Run result:** both Submitted in 5m44s, $1.66 total.  Patches: agent1=249 lines, agent2=131 lines.
**Coordination metrics:** 6 tasks (2 pre-seed + 4 lead-split), 4 done, `time_to_first_claim=29.9s`, `claims_per_agent={agent1: 2, agent2: 1}`, `updates_per_agent={agent1: 5, agent2: 2}`.
**Visible follow-up activity:**
- `/workspace/shared/tasks/` populated with 5 per-task JSON files + `_index.json` + `_log.jsonl`
- `/workspace/shared/agent2.patch` written by agent2 (4 KB)
- MCP server registered in `.claude.json`
- Task pre-seeds use the new owner field

**Eval:** **2/2 features pass** (14/14 + 20/20 tests).

Compare to the team-mode-only PR (#52) on the same task: 0/2 then, 2/2 now — the prompt fix and finer-grained coordination tools together close the gap.

## Files

| Path | Purpose |
| --- | --- |
| `src/cooperbench/agents/_team/fs_mirror.py` | filesystem snapshot helper (host) |
| `src/cooperbench/agents/_team/protocol.py` | typed request/response client (host) |
| `src/cooperbench/agents/_team/mcp_server.py` | stdio MCP server + `wait_for_message` tool |
| `src/cooperbench/agents/_team/loop_refresh.py` | `TeamPoller` for Python-loop adapters + env-driven variant |
| `src/cooperbench/agents/_team/coop_task.py` | gained `cmd_request` / `cmd_respond` / `cmd_pending` + auto-mirror call |
| `src/cooperbench/agents/_team/install_snippet.sh` | adds `coop-request` / `coop-respond` / `coop-pending` wrappers |
| `src/cooperbench/agents/_team/prompt.py` | tightened with explicit `patch.txt` submission section |
| `src/cooperbench/agents/_team/runtime.py` | exports `CONTAINER_TASKS_MIRROR_DIR`; sets `CB_TEAM_TASKS_DIR` env var |
| `src/cooperbench/agents/claude_code/adapter.py` | drops MCP script + writes `.claude.json` for team mode |
| `src/cooperbench/agents/codex/adapter.py` | drops MCP script + writes `config.toml` for team mode |
| `src/cooperbench/agents/mini_swe_agent_v2/adapter.py` | constructs `TeamPoller` when team kwargs present |
| `src/cooperbench/agents/mini_swe_agent_v2/agents/default.py` | `step()` calls `team_poller.poll()` |
| `src/cooperbench/runner/core.py` | display fix for team-mode `patch_lines` |

## Test plan

- [ ] `ruff check`, `ruff format --check`, `mypy`, `pytest tests/` (all green locally)
- [ ] `uv run cooperbench run -a claude_code -m claude-sonnet-4-5 -r <repo> -t <task> -f <f1>,<f2> --setting team --git --backend docker`
- [ ] `uv run cooperbench eval -n <name> --backend docker`
- [ ] Inspect `/workspace/shared/tasks/_index.json`, `result.json:metrics`, `.claude.json` in container
