### PR TITLE
ci: auto-deploy docs to Cloudflare Pages

### DIFF
--- a/.github/workflows/deploy-report.yml
+++ b/.github/workflows/deploy-report.yml
@@ -1,0 +1,149 @@
+name: Deploy docs to Cloudflare Pages
+
+on:
+  pull_request:
+    paths:
+      - 'docs/**'
+      - '.github/workflows/deploy-report.yml'
+  push:
+    branches: [main]
+    paths:
+      - 'docs/**'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pull-requests: write
+  deployments: write
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Generate docs/index.html
+        run: |
+          set -euo pipefail
+          mapfile -t files < <(ls -1 docs/*.html 2>/dev/null | grep -v '/index.html$' | sort -r)
+          {
+            cat <<'HTML'
+          <!doctype html>
+          <html lang="en">
+          <head>
+          <meta charset="utf-8">
+          <title>CooperBench reports</title>
+          <meta name="viewport" content="width=device-width, initial-scale=1">
+          <style>
+            html { font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", system-ui, sans-serif; color: #1a1a1a; background: #fafafa; }
+            body { max-width: 760px; margin: 56px auto; padding: 0 20px; line-height: 1.5; }
+            h1 { font-size: 22px; margin: 0 0 6px; }
+            .meta { color: #6b6b6b; font-size: 13px; margin-bottom: 28px; }
+            ul.reports { list-style: none; padding: 0; margin: 0; }
+            ul.reports li { padding: 12px 14px; border: 1px solid #e2e2e2; border-radius: 4px; margin-bottom: 8px; background: #fff; }
+            ul.reports li:hover { background: #fff7d6; }
+            ul.reports a { color: #2563eb; text-decoration: none; font-weight: 600; font-size: 14px; }
+            ul.reports .date { display: inline-block; color: #6b6b6b; font-size: 12px; margin-right: 10px; font-variant-numeric: tabular-nums; min-width: 88px; }
+            ul.reports .latest { background: #16a34a; color: #fff; font-size: 10px; padding: 1px 6px; border-radius: 10px; margin-left: 8px; vertical-align: middle; letter-spacing: .03em; }
+            .empty { color: #6b6b6b; font-style: italic; }
+            footer { margin-top: 40px; font-size: 11px; color: #6b6b6b; border-top: 1px solid #e2e2e2; padding-top: 12px; }
+          </style>
+          </head>
+          <body>
+          <h1>CooperBench reports</h1>
+          <div class="meta">Self-contained benchmark &amp; ablation reports, published on every push to <code>main</code>.</div>
+          HTML
+            if [ "${#files[@]}" -eq 0 ]; then
+              echo '<p class="empty">No reports yet.</p>'
+            else
+              echo '<ul class="reports">'
+              first=1
+              for f in "${files[@]}"; do
+                base=$(basename "$f" .html)
+                date=$(echo "$base" | grep -oE '^[0-9]{4}-[0-9]{2}-[0-9]{2}' || true)
+                title=$(grep -oE '<h1[^>]*>[^<]+</h1>' "$f" | head -1 | sed -E 's/<[^>]+>//g')
+                [ -z "$title" ] && title="$base"
+                badge=""
+                if [ $first -eq 1 ]; then badge='<span class="latest">LATEST</span>'; first=0; fi
+                printf '<li><span class="date">%s</span><a href="./%s">%s</a>%s</li>\n' "${date:-—}" "$base" "$title" "$badge"
+              done
+              echo '</ul>'
+            fi
+            cat <<'HTML'
+          <footer>Auto-generated on every push by <code>.github/workflows/deploy-report.yml</code>.</footer>
+          </body>
+          </html>
+          HTML
+          } > docs/index.html
+          echo "Wrote docs/index.html with ${#files[@]} entries"
+
+      - name: Check Cloudflare credentials
+        id: cf
+        env:
+          CF_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CF_ACCOUNT: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+        run: |
+          if [ -n "$CF_TOKEN" ] && [ -n "$CF_ACCOUNT" ]; then
+            echo "configured=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "configured=false" >> "$GITHUB_OUTPUT"
+            echo "::warning::CLOUDFLARE_API_TOKEN / CLOUDFLARE_ACCOUNT_ID are not set on this repo — skipping the Cloudflare Pages deploy. Add both secrets (repo or org level) to enable automatic publishing."
+          fi
+
+      - name: Deploy to Cloudflare Pages
+        id: deploy
+        if: steps.cf.outputs.configured == 'true'
+        uses: cloudflare/wrangler-action@v3
+        with:
+          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          command: pages deploy docs --project-name=cooperbench-reports --branch=${{ github.head_ref || github.ref_name }} --commit-hash=${{ github.event.pull_request.head.sha || github.sha }}
+
+      - name: Find latest report file
+        id: latest
+        run: |
+          latest=$(ls -1 docs/*.html 2>/dev/null | grep -v '/index\.html$' | sort | tail -1 | sed 's|^docs/||;s|\.html$||')
+          echo "slug=$latest" >> "$GITHUB_OUTPUT"
+
+      - name: Comment preview URL on PR
+        if: github.event_name == 'pull_request' && steps.cf.outputs.configured == 'true'
+        uses: actions/github-script@v7
+        env:
+          DEPLOYMENT_URL: ${{ steps.deploy.outputs.deployment-url }}
+          ALIAS_URL: ${{ steps.deploy.outputs.pages-deployment-alias-url }}
+          LATEST_SLUG: ${{ steps.latest.outputs.slug }}
+        with:
+          script: |
+            const { DEPLOYMENT_URL, ALIAS_URL, LATEST_SLUG } = process.env;
+            const lines = [
+              '<!-- cooperbench-reports-preview -->',
+              '**Cloudflare Pages preview deployed**',
+              '',
+              `- Latest report: ${ALIAS_URL || DEPLOYMENT_URL}/${LATEST_SLUG}`,
+              `- Versioned URL: ${DEPLOYMENT_URL}/${LATEST_SLUG}`,
+              `- Project root: ${ALIAS_URL || DEPLOYMENT_URL}`,
+              '',
+              `_Deployed from \`${context.sha.slice(0,7)}\` on \`${context.payload.pull_request.head.ref}\`._`,
+            ];
+            const body = lines.join('\n');
+            const { data: comments } = await github.rest.issues.listComments({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+            });
+            const existing = comments.find(c => c.body && c.body.includes('<!-- cooperbench-reports-preview -->'));
+            if (existing) {
+              await github.rest.issues.updateComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: existing.id,
+                body,
+              });
+            } else {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.issue.number,
+                body,
+              });
+            }


### PR DESCRIPTION
## Problem

PR #59 adds `docs/team_harness_ablation_report.html` but it was **never auto-deployed** — because CooperBench has **no docs-deployment pipeline**:

- The repo's original `.github/workflows/docs.yaml` (MkDocs + `mike`) was **deleted in `b61bc00` ("Updating linter")**. It was unconfigured cookiecutter scaffolding anyway (referenced a placeholder `src/your_package_name/__about__.py`, needed a `mkdocs.yml` that never existed).
- GitHub Pages is still "enabled" but points at a **`gh-pages` branch that doesn't exist**, so the live site (`cooperbench.github.io/CooperBench/`) currently returns **404**.

## Fix

Add a Cloudflare Pages workflow modeled on **`cooperbench/CooperTrain`**'s `deploy-report.yml`:

- Triggers on push to `main` and PRs touching `docs/**` (plus `workflow_dispatch`).
- Generates a `docs/index.html` landing page listing every `docs/*.html` report (title pulled from each file's `<h1>`, newest first, `LATEST` badge).
- Deploys the `docs/` directory to the Cloudflare Pages project **`cooperbench-reports`**.
- PRs get a preview deployment + a comment with the preview URL.

The report is self-contained HTML (inline CSS, no runtime data fetches), so no static-site generator is needed.

## ⚠️ Required before it works: secrets

CooperBench has **no Cloudflare secrets** yet. The deploy step **skips gracefully (green, with a warning)** until both are set — same token/account CooperTrain uses:

```
gh secret set CLOUDFLARE_API_TOKEN  --repo cooperbench/CooperBench
gh secret set CLOUDFLARE_ACCOUNT_ID --repo cooperbench/CooperBench
```

(Or promote them to org-level secrets so both repos share them.)

## Notes / decisions

- **Separate Pages project** (`cooperbench-reports`), *not* CooperTrain's `cooperbench-train-reports`: each Cloudflare Pages deploy replaces the whole project's content, so reusing CooperTrain's project would clobber its reports. This keeps both on the **same Cloudflare account** (shared secrets) but on distinct sites. Rename the `--project-name` if you'd rather merge them.
- Deploys the whole `docs/` dir, so `docs/team_harness_ablation_report.html` lands at `cooperbench-reports.pages.dev/team_harness_ablation_report`. PR #59's report deploys automatically once both this and #59 are on `main`.
