### PR TITLE
ci: publish report to shared org reports repo (stop direct deploy)

### DIFF
--- a/.github/workflows/deploy-report.yml
+++ b/.github/workflows/deploy-report.yml
@@ -1,149 +1,68 @@
-name: Deploy docs to Cloudflare Pages
+name: Publish report to org reports site
+
+# Pushes the team-harness ablation report into the private aggregator repo
+# cooperbench/reports (subfolder cooperbench/).  That repo's own CI builds
+# the combined index and deploys the public site
+# (https://cooperbench-reports.pages.dev).  We no longer deploy to
+# Cloudflare directly from here — doing so would clobber other repos'
+# reports on the shared Pages project.
 
 on:
-  pull_request:
-    paths:
-      - 'docs/**'
-      - '.github/workflows/deploy-report.yml'
   push:
     branches: [main]
     paths:
       - 'docs/**'
+      - '.github/workflows/deploy-report.yml'
   workflow_dispatch:
 
 permissions:
   contents: read
-  pull-requests: write
-  deployments: write
 
 jobs:
-  deploy:
+  publish:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
 
-      - name: Generate docs/index.html
-        run: |
-          set -euo pipefail
-          mapfile -t files < <(ls -1 docs/*.html 2>/dev/null | grep -v '/index.html$' | sort -r)
-          {
-            cat <<'HTML'
-          <!doctype html>
-          <html lang="en">
-          <head>
-          <meta charset="utf-8">
-          <title>CooperBench reports</title>
-          <meta name="viewport" content="width=device-width, initial-scale=1">
-          <style>
-            html { font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", system-ui, sans-serif; color: #1a1a1a; background: #fafafa; }
-            body { max-width: 760px; margin: 56px auto; padding: 0 20px; line-height: 1.5; }
-            h1 { font-size: 22px; margin: 0 0 6px; }
-            .meta { color: #6b6b6b; font-size: 13px; margin-bottom: 28px; }
-            ul.reports { list-style: none; padding: 0; margin: 0; }
-            ul.reports li { padding: 12px 14px; border: 1px solid #e2e2e2; border-radius: 4px; margin-bottom: 8px; background: #fff; }
-            ul.reports li:hover { background: #fff7d6; }
-            ul.reports a { color: #2563eb; text-decoration: none; font-weight: 600; font-size: 14px; }
-            ul.reports .date { display: inline-block; color: #6b6b6b; font-size: 12px; margin-right: 10px; font-variant-numeric: tabular-nums; min-width: 88px; }
-            ul.reports .latest { background: #16a34a; color: #fff; font-size: 10px; padding: 1px 6px; border-radius: 10px; margin-left: 8px; vertical-align: middle; letter-spacing: .03em; }
-            .empty { color: #6b6b6b; font-style: italic; }
-            footer { margin-top: 40px; font-size: 11px; color: #6b6b6b; border-top: 1px solid #e2e2e2; padding-top: 12px; }
-          </style>
-          </head>
-          <body>
-          <h1>CooperBench reports</h1>
-          <div class="meta">Self-contained benchmark &amp; ablation reports, published on every push to <code>main</code>.</div>
-          HTML
-            if [ "${#files[@]}" -eq 0 ]; then
-              echo '<p class="empty">No reports yet.</p>'
-            else
-              echo '<ul class="reports">'
-              first=1
-              for f in "${files[@]}"; do
-                base=$(basename "$f" .html)
-                date=$(echo "$base" | grep -oE '^[0-9]{4}-[0-9]{2}-[0-9]{2}' || true)
-                title=$(grep -oE '<h1[^>]*>[^<]+</h1>' "$f" | head -1 | sed -E 's/<[^>]+>//g')
-                [ -z "$title" ] && title="$base"
-                badge=""
-                if [ $first -eq 1 ]; then badge='<span class="latest">LATEST</span>'; first=0; fi
-                printf '<li><span class="date">%s</span><a href="./%s">%s</a>%s</li>\n' "${date:-—}" "$base" "$title" "$badge"
-              done
-              echo '</ul>'
-            fi
-            cat <<'HTML'
-          <footer>Auto-generated on every push by <code>.github/workflows/deploy-report.yml</code>.</footer>
-          </body>
-          </html>
-          HTML
-          } > docs/index.html
-          echo "Wrote docs/index.html with ${#files[@]} entries"
-
-      - name: Check Cloudflare credentials
-        id: cf
+      - name: Check publish credentials
+        id: guard
         env:
-          CF_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
-          CF_ACCOUNT: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          APP_ID: ${{ secrets.REPORTS_APP_ID }}
+          APP_KEY: ${{ secrets.REPORTS_APP_PRIVATE_KEY }}
         run: |
-          if [ -n "$CF_TOKEN" ] && [ -n "$CF_ACCOUNT" ]; then
-            echo "configured=true" >> "$GITHUB_OUTPUT"
+          if [ -n "$APP_ID" ] && [ -n "$APP_KEY" ]; then
+            echo "ok=true" >> "$GITHUB_OUTPUT"
           else
-            echo "configured=false" >> "$GITHUB_OUTPUT"
-            echo "::warning::CLOUDFLARE_API_TOKEN / CLOUDFLARE_ACCOUNT_ID are not set on this repo — skipping the Cloudflare Pages deploy. Add both secrets (repo or org level) to enable automatic publishing."
+            echo "ok=false" >> "$GITHUB_OUTPUT"
+            echo "::warning::REPORTS_APP_ID / REPORTS_APP_PRIVATE_KEY not set — skipping publish to cooperbench/reports."
           fi
 
-      - name: Deploy to Cloudflare Pages
-        id: deploy
-        if: steps.cf.outputs.configured == 'true'
-        uses: cloudflare/wrangler-action@v3
+      - name: Mint reports-repo token
+        id: token
+        if: steps.guard.outputs.ok == 'true'
+        uses: actions/create-github-app-token@v1
         with:
-          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
-          accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
-          command: pages deploy docs --project-name=cooperbench-reports --branch=${{ github.head_ref || github.ref_name }} --commit-hash=${{ github.event.pull_request.head.sha || github.sha }}
+          app-id: ${{ secrets.REPORTS_APP_ID }}
+          private-key: ${{ secrets.REPORTS_APP_PRIVATE_KEY }}
+          owner: cooperbench
+          repositories: reports
 
-      - name: Find latest report file
-        id: latest
-        run: |
-          latest=$(ls -1 docs/*.html 2>/dev/null | grep -v '/index\.html$' | sort | tail -1 | sed 's|^docs/||;s|\.html$||')
-          echo "slug=$latest" >> "$GITHUB_OUTPUT"
-
-      - name: Comment preview URL on PR
-        if: github.event_name == 'pull_request' && steps.cf.outputs.configured == 'true'
-        uses: actions/github-script@v7
+      - name: Publish report into cooperbench/reports
+        if: steps.guard.outputs.ok == 'true'
         env:
-          DEPLOYMENT_URL: ${{ steps.deploy.outputs.deployment-url }}
-          ALIAS_URL: ${{ steps.deploy.outputs.pages-deployment-alias-url }}
-          LATEST_SLUG: ${{ steps.latest.outputs.slug }}
-        with:
-          script: |
-            const { DEPLOYMENT_URL, ALIAS_URL, LATEST_SLUG } = process.env;
-            const lines = [
-              '<!-- cooperbench-reports-preview -->',
-              '**Cloudflare Pages preview deployed**',
-              '',
-              `- Latest report: ${ALIAS_URL || DEPLOYMENT_URL}/${LATEST_SLUG}`,
-              `- Versioned URL: ${DEPLOYMENT_URL}/${LATEST_SLUG}`,
-              `- Project root: ${ALIAS_URL || DEPLOYMENT_URL}`,
-              '',
-              `_Deployed from \`${context.sha.slice(0,7)}\` on \`${context.payload.pull_request.head.ref}\`._`,
-            ];
-            const body = lines.join('\n');
-            const { data: comments } = await github.rest.issues.listComments({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              issue_number: context.issue.number,
-            });
-            const existing = comments.find(c => c.body && c.body.includes('<!-- cooperbench-reports-preview -->'));
-            if (existing) {
-              await github.rest.issues.updateComment({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                comment_id: existing.id,
-                body,
-              });
-            } else {
-              await github.rest.issues.createComment({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                issue_number: context.issue.number,
-                body,
-              });
-            }
+          GH_TOKEN: ${{ steps.token.outputs.token }}
+        run: |
+          set -euo pipefail
+          git clone --depth 1 "https://x-access-token:${GH_TOKEN}@github.com/cooperbench/reports.git" _reports
+          mkdir -p _reports/cooperbench
+          cp docs/team_harness_ablation_report.html _reports/cooperbench/
+          cd _reports
+          git add -A
+          if git diff --cached --quiet; then
+            echo "No report changes to publish."
+            exit 0
+          fi
+          git config user.name "cooperbench-reports-publisher[bot]"
+          git config user.email "cooperbench-reports-publisher[bot]@users.noreply.github.com"
+          git commit -m "report(cooperbench): update from ${GITHUB_SHA:0:7}"
+          git push


### PR DESCRIPTION
Part of consolidating org reports into the private `cooperbench/reports` aggregator (public site: https://cooperbench-reports.pages.dev).

**Change:** CooperBench's `deploy-report.yml` no longer runs `wrangler pages deploy` against the shared `cooperbench-reports` Cloudflare project. Instead it mints a GitHub App token (`cooperbench-reports-publisher`, scoped to `cooperbench/reports`) and pushes `docs/team_harness_ablation_report.html` into `cooperbench/reports/cooperbench/`. The reports repo's CI rebuilds the combined index and deploys the public site.

**Why:** the Cloudflare project is now shared with CooperTrain; a direct deploy from here would overwrite the other repos' reports (each `pages deploy` replaces the whole project). This closes that clobber hazard.

Secrets used: `REPORTS_APP_ID`, `REPORTS_APP_PRIVATE_KEY` (already set on this repo). The publish step skips with a warning if they're absent.
