### PR TITLE
plan_execute: new two-phase setting (plan then execute)

### DIFF
--- a/src/cooperbench/agents/openhands_agent_sdk/adapter.py
+++ b/src/cooperbench/agents/openhands_agent_sdk/adapter.py
@@ -246,6 +246,56 @@ def _submission_instructions(*, is_coop: bool) -> str:
     )
 
 
+def _plan_submission_instructions(*, is_coop: bool) -> str:
+    """Submission block for the **plan** phase of the ``plan_execute`` setting.
+
+    The agent writes a free-form plan to ``plan.txt`` and finishes. No code
+    is edited. In coop, the agent can coordinate over messaging/git but the
+    plan content itself is the only artifact carried to the execute phase.
+    """
+    coop_goal = (
+        "\n## Why two phases\n\n"
+        "You are in the PLAN phase of a two-phase workflow with your teammate.\n"
+        "In the next phase, you and your teammate will each write a patch.\n"
+        "Those patches are merged automatically — **if your patch and your\n"
+        "teammate's patch touch any of the same lines, BOTH patches are\n"
+        "thrown away.**\n\n"
+        "The whole point of this planning phase is to *prevent that*: use the\n"
+        "messaging / git tools NOW to agree on who owns which files, functions,\n"
+        "and regions, so your eventual patches are line-disjoint. Discuss\n"
+        "scope, edge cases, and any shared helpers you'd both want to change.\n"
+        "Do not skip the coordination — a great solo plan that conflicts with\n"
+        "your teammate's plan is worth nothing.\n"
+        if is_coop
+        else ""
+    )
+    return (
+        "\n\n## Planning task\n"
+        f"{coop_goal}"
+        "\n## What to do\n\n"
+        "**Do NOT edit any source files. Do NOT write a patch.** Your only\n"
+        "job in this phase is to produce a plan and save it to ``plan.txt``\n"
+        "at the repo root (``/workspace/repo/plan.txt``).\n\n"
+        "Explore the codebase first. Then write a plan that captures:\n\n"
+        "- which files you will modify\n"
+        "- which functions / classes / regions inside those files\n"
+        "- the approach (what change, in what order, why)\n"
+        "- anything you discovered during exploration that the executor\n"
+        "  will need to know (constraints, gotchas, neighbouring tests)\n\n"
+        "Write the plan free-form — whatever shape best captures the work.\n"
+        "It will be passed **verbatim** to a separate executor agent that has\n"
+        "**no other context** (no feature spec, no teammate plan, no logs\n"
+        "from this conversation). Make sure the plan is self-contained.\n\n"
+        "```bash\n"
+        "cat > plan.txt <<'PLAN'\n"
+        "<your plan here>\n"
+        "PLAN\n"
+        "```\n\n"
+        "Once ``plan.txt`` is written and you're confident it's complete,\n"
+        "finish the task. Do not write code in this phase.\n"
+    )
+
+
 def _collect_sandbox_credentials(
     coop_info: dict | None,
     *,
@@ -481,6 +531,11 @@ class OpenHandsSDKRunner:
         
         config = config or {}
         backend = config.get("backend", "docker")
+        # plan_execute overrides: the runner can replace the default
+        # patch.txt submission template + extracted artifact so the same
+        # adapter handles both the "plan" and "execute" phases.
+        submission_template_override: str | None = config.get("submission_template")
+        submission_artifact: str = config.get("submission_artifact", "patch.txt")
 
         # Determine if this is a coop run
         is_coop = (messaging_enabled or git_enabled) and agents and len(agents) > 1
@@ -655,12 +710,20 @@ class OpenHandsSDKRunner:
                     visualizer=None,
                 )
 
-                # Send task and run the conversation. Append the patch.txt
-                # submission instructions so the agent writes its diff to a
-                # known file before finishing (matches mini_swe_agent's flow).
+                # Send task and run the conversation. Append the submission
+                # instructions so the agent writes its artifact to a known
+                # file before finishing (matches mini_swe_agent's flow). The
+                # runner can override the appended block via
+                # ``config["submission_template"]`` — used by plan_execute
+                # to swap in plan-phase instructions.
                 # Message checking for coop mode happens inside the agent loop
                 # (in LocalConversation._check_inbox_messages before each step)
-                conversation.send_message(task + _submission_instructions(is_coop=is_coop))
+                submission_block = (
+                    submission_template_override
+                    if submission_template_override is not None
+                    else _submission_instructions(is_coop=is_coop)
+                )
+                conversation.send_message(task + submission_block)
                 try:
                     conversation.run(blocking=True, timeout=float(self.timeout))
                     status = "Submitted"
@@ -675,14 +738,17 @@ class OpenHandsSDKRunner:
                         error = error_str
                         status = "Error"
 
-                # Read patch.txt that the agent wrote during submission.
+                # Read the submission artifact the agent wrote.
                 # Mirrors mini_swe_agent_v2's submission flow (see config/coop.yaml):
-                # the agent is prompted to write its diff to patch.txt before
-                # finishing, and we extract that file as-is.
+                # the agent is prompted to write its artifact to a known file
+                # before finishing, and we extract that file as-is. The
+                # runner can override the filename via
+                # ``config["submission_artifact"]`` — used by plan_execute
+                # to extract plan.txt during the plan phase.
                 patch = ""
                 try:
                     patch_result = workspace.execute_command(
-                        "cat patch.txt 2>/dev/null",
+                        f"cat {submission_artifact} 2>/dev/null",
                         cwd="/workspace/repo",
                         timeout=30.0,
                     )
@@ -690,7 +756,7 @@ class OpenHandsSDKRunner:
                         from cooperbench.agents._coop.runtime import normalize_patch
                         patch = normalize_patch(patch_result.stdout or "")
                 except Exception as e:
-                    logger.warning(f"Failed to read patch.txt: {e}")
+                    logger.warning(f"Failed to read {submission_artifact}: {e}")
 
                 # Get cost and token usage from conversation stats
                 try:

--- a/src/cooperbench/cli.py
+++ b/src/cooperbench/cli.py
@@ -157,11 +157,13 @@ def main():
     )
     run_parser.add_argument(
         "--setting",
-        choices=["coop", "solo", "team"],
+        choices=["coop", "solo", "team", "plan_execute"],
         default="coop",
-        help="Benchmark setting: coop (N peers), solo (1 agent), or team "
+        help="Benchmark setting: coop (N peers), solo (1 agent), team "
         "(N agents with shared task list, lead/member roles, shared "
-        "scratchpad) (default: coop)",
+        "scratchpad), or plan_execute (two-phase: agents plan first, then "
+        "fresh containers execute against their own plan; openhands_sdk "
+        "only). (default: coop)",
     )
     # Per-feature toggles for the team harness — flip any of these off
     # to ablate that coordination mechanism while keeping the others on.

--- a/src/cooperbench/eval/evaluate.py
+++ b/src/cooperbench/eval/evaluate.py
@@ -266,7 +266,7 @@ def _run_gcp_batch(
                 "status": batch_result.merge_status,
                 "strategy": batch_result.merge_strategy,
             }
-            if batch_result.setting == "coop"
+            if batch_result.setting in ("coop", "plan_execute")
             else None,
             "feature1": {
                 "passed": batch_result.feature1_passed,
@@ -377,7 +377,7 @@ def _evaluate_single(
             "repo": repo,
             "task_id": task_id,
             "features": features,
-            "setting": "coop",
+            "setting": setting,
             "apply_status": result.get("apply_status"),
             "merge": result.get("merge", {}),
             "feature1": result.get("feature1", {}),

--- a/src/cooperbench/eval/runs.py
+++ b/src/cooperbench/eval/runs.py
@@ -45,8 +45,8 @@ def discover_runs(
     if subset:
         subset_data = load_subset(subset, dataset_dir=dataset_dir)
 
-    # Check for new structure (solo/, coop/, team/)
-    for setting in ["solo", "coop", "team"]:
+    # Check for new structure (solo/, coop/, team/, plan_execute/)
+    for setting in ["solo", "coop", "team", "plan_execute"]:
         setting_dir = log_dir / setting
         if setting_dir.exists():
             runs.extend(

--- a/src/cooperbench/runner/coop.py
+++ b/src/cooperbench/runner/coop.py
@@ -80,135 +80,50 @@ def execute_coop(
         if not agents_had_error:
             return {"skipped": True, **prev_result}
 
-    namespaced_redis = f"{redis_url}#run:{run_id}"
-
-    # Create git server if enabled.
-    # openhands_sdk self-manages its git server on the Modal backend (because
-    # Modal sandboxes can't reach a host-side git daemon). On the docker
-    # backend it uses the shared DockerGitServer like every other adapter.
-    git_server = None
-    git_server_url = None
-    git_network = None
-    if git_enabled and not (agent_name == "openhands_sdk" and backend == "modal"):
-        if not quiet:
-            console.print("  [dim]git[/dim] creating shared server...")
-        app = modal.App.lookup("cooperbench", create_if_missing=True) if backend == "modal" else None
-
-        # Build git server kwargs based on backend
-        git_server_kwargs = {"backend": backend, "run_id": run_id, "app": app}
-        if backend == "gcp":
-            config = ConfigManager()
-            if project_id := config.get("gcp_project_id"):
-                git_server_kwargs["project_id"] = project_id
-            if zone := config.get("gcp_zone"):
-                git_server_kwargs["zone"] = zone
-
-        git_server = create_git_server(**git_server_kwargs)
-        git_server_url = git_server.url
-        git_network = getattr(git_server, "network_name", None)
-        if not quiet:
-            console.print(f"  [dim]git[/dim] [green]ready[/green] {git_server_url}")
-
-    results = {}
-    threads = []
-
-    def run_thread(agent_id: str, feature_id: int):
-        try:
-            results[agent_id] = _spawn_agent(
-                repo_name=repo_name,
-                task_id=task_id,
-                feature_id=feature_id,
-                agent_name=agent_name,
-                model_name=model_name,
-                agent_id=agent_id,
-                agents=agents,
-                redis_url=namespaced_redis if messaging_enabled and n_agents > 1 else None,
-                git_server_url=git_server_url,
-                git_enabled=git_enabled,
-                git_network=git_network,
-                messaging_enabled=messaging_enabled,
-                quiet=quiet,
-                backend=backend,
-                agent_config=agent_config,
-                run_name=run_name,
-                features=features,
-                dataset_dir=dataset_dir,
-                logs_dir=logs_dir,
-            )
-        except Exception as e:
-            results[agent_id] = {
-                "feature_id": feature_id,
-                "agent_id": agent_id,
-                "status": "Error",
-                "patch": "",
-                "cost": 0,
-                "steps": 0,
-                "messages": [],
-                "error": str(e),
-            }
+    namespaced_redis, git_server, git_server_url, git_network = setup_pair_infra(
+        redis_url=redis_url,
+        run_id=run_id,
+        agent_name=agent_name,
+        backend=backend,
+        git_enabled=git_enabled,
+        quiet=quiet,
+    )
 
     try:
-        # Sort features to ensure agent assignment matches sorted directory name
-        sorted_features = sorted(features)
-        for agent_id, feature_id in zip(agents, sorted_features):
-            t = threading.Thread(target=run_thread, args=(agent_id, feature_id))
-            threads.append(t)
-            t.start()
-
-        for t in threads:
-            t.join()
+        phase = _run_pair_phase(
+            repo_name=repo_name,
+            task_id=task_id,
+            features=features,
+            agents=agents,
+            agent_name=agent_name,
+            model_name=model_name,
+            redis_url=namespaced_redis,
+            git_server_url=git_server_url,
+            git_enabled=git_enabled,
+            git_network=git_network,
+            messaging_enabled=messaging_enabled,
+            backend=backend,
+            agent_config=agent_config,
+            run_name=run_name,
+            dataset_dir=dataset_dir,
+            logs_dir=logs_dir,
+            log_dir=log_dir,
+            quiet=quiet,
+            artifact_suffix="patch",
+        )
     finally:
-        # Cleanup git server
         if git_server:
             git_server.cleanup()
+
+    results = phase["results"]
+    sent_msgs = phase["conversation"]
+    total_cost = phase["total_cost"]
+    total_steps = phase["total_steps"]
 
     end_time = datetime.now()
     duration = (end_time - start_time).total_seconds()
 
-    total_cost = sum(r.get("cost", 0) for r in results.values())
-    total_steps = sum(r.get("steps", 0) for r in results.values())
-
-    # Save files
-    log_dir.mkdir(parents=True, exist_ok=True)
-
-    # Extract conversation (inter-agent messages)
-    conversation = _extract_conversation(results, agents)
-
-    # Sort by timestamp and dedupe (keep only sent messages, not received).
-    # See ``_message_timestamp_key`` for why coercion is needed.
-    sent_msgs = [m for m in conversation if not m.get("received")]
-    sent_msgs.sort(key=_message_timestamp_key)
-
-    # Save conversation
-    with open(log_dir / "conversation.json", "w") as f:
-        json.dump(sent_msgs, f, indent=2, default=str)
-
-    for agent_id in agents:
-        r = results[agent_id]
-        fid = r["feature_id"]
-
-        patch_file = log_dir / f"agent{fid}.patch"
-        patch_file.write_text(r.get("patch", ""))
-
-        traj_file = log_dir / f"agent{fid}_traj.json"
-        with open(traj_file, "w") as f:
-            json.dump(
-                {
-                    "repo": repo_name,
-                    "task_id": task_id,
-                    "feature_id": fid,
-                    "agent_id": agent_id,
-                    "model": model_name,
-                    "status": r.get("status"),
-                    "cost": r.get("cost"),
-                    "steps": r.get("steps"),
-                    "messages": r.get("messages", []),
-                },
-                f,
-                indent=2,
-                default=str,
-            )
-
+    sorted_features = sorted(features)
     result_data = {
         "repo": repo_name,
         "task_id": task_id,
@@ -275,6 +190,11 @@ def _spawn_agent(
     features: list[int] | None = None,
     dataset_dir: Path | str | None = None,
     logs_dir: Path | str | None = None,
+    *,
+    task_override: str | None = None,
+    extra_config: dict | None = None,
+    log_dir_override: str | None = None,
+    setting_subdir: str = "coop",
 ) -> dict:
     """Spawn a single agent on a feature using the agent framework adapter.
 
@@ -282,23 +202,40 @@ def _spawn_agent(
         agent_config: Path to agent-specific configuration file (optional)
         dataset_dir: Root of the dataset tree.  Defaults to ``./dataset``.
         logs_dir: Root to write run logs under.  Defaults to ``./logs``.
+        task_override: If set, use this string as the task message instead
+            of reading ``feature.md``. Used by ``plan_execute``'s Phase 2
+            where the task is the agent's own ``plan.txt`` content.
+        extra_config: Optional dict merged into the ``config`` passed to the
+            adapter (e.g. ``submission_template`` / ``submission_artifact``
+            overrides for ``plan_execute``).
+        log_dir_override: Optional explicit log directory string to pass to
+            the adapter (skips the default ``logs/<run>/<setting>/...`` path
+            computation). Used to point Phase 1 at a ``phase1/`` subdir.
+        setting_subdir: First subdir under ``logs/<run>/`` (default
+            ``"coop"``; ``"plan_execute"`` for the plan_execute setting).
     """
     root = Path(dataset_dir) if dataset_dir is not None else DEFAULT_DATASET_DIR
     task_dir = root / repo_name / f"task{task_id}"
     logs_root = Path(logs_dir) if logs_dir is not None else DEFAULT_LOGS_DIR
-    feature_file = task_dir / f"feature{feature_id}" / "feature.md"
 
-    if not feature_file.exists():
-        raise FileNotFoundError(f"Feature file not found: {feature_file}")
+    if task_override is not None:
+        task = task_override
+    else:
+        feature_file = task_dir / f"feature{feature_id}" / "feature.md"
+        if not feature_file.exists():
+            raise FileNotFoundError(f"Feature file not found: {feature_file}")
+        task = feature_file.read_text()
 
-    task = feature_file.read_text()
     image = get_image_name(repo_name, task_id)
 
     # Compute log directory path
-    log_dir_path = None
-    if run_name and features:
+    if log_dir_override is not None:
+        log_dir_path: str | None = log_dir_override
+    elif run_name and features:
         feature_str = "_".join(f"f{f}" for f in sorted(features))
-        log_dir_path = str(logs_root / run_name / "coop" / repo_name / str(task_id) / feature_str)
+        log_dir_path = str(logs_root / run_name / setting_subdir / repo_name / str(task_id) / feature_str)
+    else:
+        log_dir_path = None
 
     if not quiet:
         console.print(f"  [dim]{agent_id}[/dim] starting...")
@@ -317,6 +254,8 @@ def _spawn_agent(
                     config.update(agent_config_dict)
         else:
             raise FileNotFoundError(f"Agent config file not found: {agent_config}")
+    if extra_config:
+        config.update(extra_config)
 
     # Use the agent framework adapter
     runner = get_runner(agent_name)
@@ -423,3 +362,171 @@ def _extract_conversation(results: dict, agents: list[str]) -> list[dict]:
                     )
 
     return conversation
+
+
+def _run_pair_phase(
+    *,
+    repo_name: str,
+    task_id: int,
+    features: list[int],
+    agents: list[str],
+    agent_name: str,
+    model_name: str,
+    redis_url: str | None,
+    git_server_url: str | None,
+    git_enabled: bool,
+    git_network: str | None,
+    messaging_enabled: bool,
+    backend: str,
+    agent_config: str | None,
+    run_name: str,
+    dataset_dir: Path | str | None,
+    logs_dir: Path | str | None,
+    log_dir: Path,
+    quiet: bool = False,
+    task_override_per_agent: dict[str, str] | None = None,
+    extra_config: dict | None = None,
+    artifact_suffix: str = "patch",
+) -> dict:
+    """Run one phase of a pair: thread N agents through ``_spawn_agent`` and
+    persist per-agent artifacts to ``log_dir``.
+
+    Shared by ``execute_coop`` (single phase, artifact_suffix='patch') and
+    ``execute_plan_execute`` (two phases: 'plan' then 'patch'). Does NOT
+    write ``result.json`` — the caller owns that, so it can roll up multiple
+    phases into one result file.
+
+    Returns a dict with ``results`` (per-agent), ``conversation``,
+    ``total_cost``, ``total_steps``.
+    """
+    n_agents = len(features)
+    sorted_features = sorted(features)
+    results: dict = {}
+    threads: list[threading.Thread] = []
+
+    def run_thread(agent_id: str, feature_id: int):
+        try:
+            results[agent_id] = _spawn_agent(
+                repo_name=repo_name,
+                task_id=task_id,
+                feature_id=feature_id,
+                agent_name=agent_name,
+                model_name=model_name,
+                agent_id=agent_id,
+                agents=agents,
+                redis_url=redis_url if messaging_enabled and n_agents > 1 else None,
+                git_server_url=git_server_url,
+                git_enabled=git_enabled,
+                git_network=git_network,
+                messaging_enabled=messaging_enabled,
+                quiet=quiet,
+                backend=backend,
+                agent_config=agent_config,
+                run_name=run_name,
+                features=features,
+                dataset_dir=dataset_dir,
+                logs_dir=logs_dir,
+                task_override=(task_override_per_agent or {}).get(agent_id),
+                extra_config=extra_config,
+                log_dir_override=str(log_dir),
+            )
+        except Exception as e:
+            results[agent_id] = {
+                "feature_id": feature_id,
+                "agent_id": agent_id,
+                "status": "Error",
+                "patch": "",
+                "cost": 0,
+                "steps": 0,
+                "messages": [],
+                "error": str(e),
+            }
+
+    for agent_id, feature_id in zip(agents, sorted_features):
+        t = threading.Thread(target=run_thread, args=(agent_id, feature_id))
+        threads.append(t)
+        t.start()
+    for t in threads:
+        t.join()
+
+    log_dir.mkdir(parents=True, exist_ok=True)
+    conversation = _extract_conversation(results, agents)
+    sent_msgs = [m for m in conversation if not m.get("received")]
+    sent_msgs.sort(key=_message_timestamp_key)
+    with open(log_dir / "conversation.json", "w") as f:
+        json.dump(sent_msgs, f, indent=2, default=str)
+
+    for agent_id in agents:
+        r = results[agent_id]
+        fid = r["feature_id"]
+        artifact_file = log_dir / f"agent{fid}.{artifact_suffix}"
+        artifact_file.write_text(r.get("patch", ""))
+        traj_file = log_dir / f"agent{fid}_traj.json"
+        with open(traj_file, "w") as f:
+            json.dump(
+                {
+                    "repo": repo_name,
+                    "task_id": task_id,
+                    "feature_id": fid,
+                    "agent_id": agent_id,
+                    "model": model_name,
+                    "status": r.get("status"),
+                    "cost": r.get("cost"),
+                    "steps": r.get("steps"),
+                    "messages": r.get("messages", []),
+                },
+                f,
+                indent=2,
+                default=str,
+            )
+
+    total_cost = sum(r.get("cost", 0) for r in results.values())
+    total_steps = sum(r.get("steps", 0) for r in results.values())
+
+    return {
+        "results": results,
+        "conversation": sent_msgs,
+        "total_cost": total_cost,
+        "total_steps": total_steps,
+    }
+
+
+def setup_pair_infra(
+    *,
+    redis_url: str,
+    run_id: str,
+    agent_name: str,
+    backend: str,
+    git_enabled: bool,
+    quiet: bool = False,
+) -> tuple[str, object | None, str | None, str | None]:
+    """Create the per-pair shared infra: namespaced Redis URL, git server.
+
+    Returns ``(namespaced_redis, git_server, git_server_url, git_network)``.
+    Caller is responsible for ``git_server.cleanup()`` in a finally block.
+    Mirrors the body of ``execute_coop`` lines 83-110 so ``execute_coop``
+    and ``execute_plan_execute`` share the exact same setup.
+    """
+    namespaced_redis = f"{redis_url}#run:{run_id}"
+
+    git_server = None
+    git_server_url: str | None = None
+    git_network: str | None = None
+    if git_enabled and not (agent_name == "openhands_sdk" and backend == "modal"):
+        if not quiet:
+            console.print("  [dim]git[/dim] creating shared server...")
+        app = modal.App.lookup("cooperbench", create_if_missing=True) if backend == "modal" else None
+        git_server_kwargs: dict = {"backend": backend, "run_id": run_id, "app": app}
+        if backend == "gcp":
+            cfg = ConfigManager()
+            if project_id := cfg.get("gcp_project_id"):
+                git_server_kwargs["project_id"] = project_id
+            if zone := cfg.get("gcp_zone"):
+                git_server_kwargs["zone"] = zone
+        git_server = create_git_server(**git_server_kwargs)
+        git_server_url = git_server.url
+        git_network = getattr(git_server, "network_name", None)
+        if not quiet:
+            console.print(f"  [dim]git[/dim] [green]ready[/green] {git_server_url}")
+
+    return namespaced_redis, git_server, git_server_url, git_network

--- a/src/cooperbench/runner/core.py
+++ b/src/cooperbench/runner/core.py
@@ -21,6 +21,7 @@ from rich.table import Table
 
 from cooperbench.infra.redis import ensure_redis
 from cooperbench.runner.coop import execute_coop
+from cooperbench.runner.plan_execute import execute_plan_execute
 from cooperbench.runner.solo import execute_solo
 from cooperbench.runner.tasks import discover_tasks
 from cooperbench.runner.team import execute_team
@@ -100,6 +101,7 @@ def run(
     is_single = len(tasks) == 1
     is_solo = setting == "solo"
     is_team = setting == "team"
+    is_plan_execute = setting == "plan_execute"
 
     _print_header(
         run_name, setting, tasks, agent, model_name, concurrency, is_single, is_solo, git_enabled, messaging_enabled
@@ -135,6 +137,24 @@ def run(
                 model_name=model_name,
                 force=force,
                 quiet=not is_single,
+                backend=backend,
+                agent_config=agent_config,
+                dataset_dir=dataset_dir,
+                logs_dir=logs_dir,
+            )
+        elif is_plan_execute:
+            return execute_plan_execute(
+                repo_name=task_info["repo"],
+                task_id=task_info["task_id"],
+                features=task_info["features"],
+                run_name=run_name,
+                agent_name=agent,
+                model_name=model_name,
+                redis_url=redis_url,
+                force=force,
+                quiet=not is_single,
+                git_enabled=git_enabled,
+                messaging_enabled=messaging_enabled,
                 backend=backend,
                 agent_config=agent_config,
                 dataset_dir=dataset_dir,

--- a/src/cooperbench/runner/plan_execute.py
+++ b/src/cooperbench/runner/plan_execute.py
@@ -1,0 +1,288 @@
+"""plan_execute mode — two-phase coop.
+
+Phase 1 (plan): both agents see the feature spec and are instructed to plan
+only, writing free-form ``plan.txt`` files. They have the full coop toolset
+(messaging + git) so they can coordinate to avoid eventual merge conflicts.
+
+Phase 2 (execute): two fresh agent containers. Each agent's task message is
+**its own ``plan.txt`` verbatim** — no feature spec, no teammate plan, no
+Phase 1 conversation log. They still have the full coop toolset and write
+``patch.txt`` exactly like the default coop flow. Eval runs against Phase 2
+patches only.
+
+Shares all per-pair primitives with ``execute_coop`` via the helpers in
+``coop.py``; this module is the orchestrator that wires the two phases.
+"""
+
+from __future__ import annotations
+
+import json
+import uuid
+from datetime import datetime
+from pathlib import Path
+
+from cooperbench.runner.coop import _run_pair_phase, setup_pair_infra
+from cooperbench.runner.tasks import DEFAULT_LOGS_DIR
+
+
+def execute_plan_execute(
+    repo_name: str,
+    task_id: int,
+    features: list[int],
+    run_name: str,
+    agent_name: str = "openhands_sdk",
+    model_name: str = "vertex_ai/gemini-3-flash-preview",
+    redis_url: str = "redis://localhost:6379",
+    force: bool = False,
+    quiet: bool = False,
+    git_enabled: bool = False,
+    messaging_enabled: bool = True,
+    backend: str = "docker",
+    agent_config: str | None = None,
+    dataset_dir: Path | str | None = None,
+    logs_dir: Path | str | None = None,
+) -> dict | None:
+    """Two-phase coop: plan → execute. Same signature as ``execute_coop``."""
+    if agent_name != "openhands_sdk":
+        raise NotImplementedError(
+            f"--setting plan_execute is only supported with -a openhands_sdk "
+            f"in v1 (got -a {agent_name}). The other adapters need to honour "
+            f"config['submission_template'] and config['submission_artifact'] "
+            f"first."
+        )
+
+    n_agents = len(features)
+    agents = [f"agent{i + 1}" for i in range(n_agents)]
+    sorted_features = sorted(features)
+    run_id = uuid.uuid4().hex[:8]
+    start_time = datetime.now()
+
+    logs_root = Path(logs_dir) if logs_dir is not None else DEFAULT_LOGS_DIR
+    feature_str = "_".join(f"f{f}" for f in sorted_features)
+    pair_log_dir = logs_root / run_name / "plan_execute" / repo_name / str(task_id) / feature_str
+    phase1_log_dir = pair_log_dir / "phase1"
+    result_file = pair_log_dir / "result.json"
+
+    if result_file.exists() and not force:
+        with open(result_file) as f:
+            prev_result = json.load(f)
+        agents_had_error = any(a.get("status") == "Error" for a in prev_result.get("agents", {}).values())
+        if not agents_had_error:
+            return {"skipped": True, **prev_result}
+
+    # Build the plan-phase submission template once. Coop-aware so the
+    # template references the teammate when there's more than one agent.
+    from cooperbench.agents.openhands_agent_sdk.adapter import (
+        _plan_submission_instructions,
+    )
+
+    is_coop = messaging_enabled and n_agents > 1
+    plan_template = _plan_submission_instructions(is_coop=is_coop)
+
+    namespaced_redis, git_server, git_server_url, git_network = setup_pair_infra(
+        redis_url=redis_url,
+        run_id=run_id,
+        agent_name=agent_name,
+        backend=backend,
+        git_enabled=git_enabled,
+        quiet=quiet,
+    )
+
+    try:
+        # ─── Phase 1: plan ───────────────────────────────────────────────
+        phase1 = _run_pair_phase(
+            repo_name=repo_name,
+            task_id=task_id,
+            features=features,
+            agents=agents,
+            agent_name=agent_name,
+            model_name=model_name,
+            redis_url=namespaced_redis,
+            git_server_url=git_server_url,
+            git_enabled=git_enabled,
+            git_network=git_network,
+            messaging_enabled=messaging_enabled,
+            backend=backend,
+            agent_config=agent_config,
+            run_name=run_name,
+            dataset_dir=dataset_dir,
+            logs_dir=logs_dir,
+            log_dir=phase1_log_dir,
+            quiet=quiet,
+            extra_config={
+                "submission_template": plan_template,
+                "submission_artifact": "plan.txt",
+            },
+            artifact_suffix="plan",
+        )
+
+        # Persist phase 1's own result.json for inspection
+        _write_phase_result(
+            log_dir=phase1_log_dir,
+            phase_name="plan",
+            repo_name=repo_name,
+            task_id=task_id,
+            sorted_features=sorted_features,
+            run_id=run_id,
+            run_name=run_name,
+            agent_name=agent_name,
+            model_name=model_name,
+            phase=phase1,
+        )
+
+        # The plan content for each agent lives in result.patch (the adapter
+        # cat's whatever ``submission_artifact`` it was told to read).
+        plan_per_agent = {agent_id: r.get("patch") or "" for agent_id, r in phase1["results"].items()}
+
+        # If a plan came back empty, the executor will get an empty task.
+        # Warn loudly — but don't abort; let the run produce evidence.
+        for agent_id, plan in plan_per_agent.items():
+            if not plan.strip():
+                from cooperbench.utils import console
+
+                console.print(f"  [yellow]warning[/yellow] phase 1 produced empty plan for {agent_id}")
+
+        # ─── Phase 2: execute ────────────────────────────────────────────
+        phase2 = _run_pair_phase(
+            repo_name=repo_name,
+            task_id=task_id,
+            features=features,
+            agents=agents,
+            agent_name=agent_name,
+            model_name=model_name,
+            redis_url=namespaced_redis,
+            git_server_url=git_server_url,
+            git_enabled=git_enabled,
+            git_network=git_network,
+            messaging_enabled=messaging_enabled,
+            backend=backend,
+            agent_config=agent_config,
+            run_name=run_name,
+            dataset_dir=dataset_dir,
+            logs_dir=logs_dir,
+            log_dir=pair_log_dir,
+            quiet=quiet,
+            task_override_per_agent=plan_per_agent,
+            # No extra_config → adapter falls back to the default patch.txt
+            # submission template and reads patch.txt.
+            artifact_suffix="patch",
+        )
+    finally:
+        if git_server:
+            git_server.cleanup()
+
+    end_time = datetime.now()
+    duration = (end_time - start_time).total_seconds()
+
+    # Combined cost/steps roll up both phases. Agent-level fields come from
+    # phase 2 (the executor — that's what eval looks at), but cost / steps
+    # / tokens sum both phases.
+    p1_results = phase1["results"]
+    p2_results = phase2["results"]
+
+    def combined_agent(agent_id: str) -> dict:
+        p1 = p1_results.get(agent_id, {})
+        p2 = p2_results.get(agent_id, {})
+        return {
+            "feature_id": p2.get("feature_id"),
+            "status": p2.get("status"),
+            "cost": (p1.get("cost", 0) or 0) + (p2.get("cost", 0) or 0),
+            "steps": (p1.get("steps", 0) or 0) + (p2.get("steps", 0) or 0),
+            "input_tokens": (p1.get("input_tokens", 0) or 0) + (p2.get("input_tokens", 0) or 0),
+            "output_tokens": (p1.get("output_tokens", 0) or 0) + (p2.get("output_tokens", 0) or 0),
+            "cache_read_tokens": (p1.get("cache_read_tokens", 0) or 0) + (p2.get("cache_read_tokens", 0) or 0),
+            "cache_write_tokens": (p1.get("cache_write_tokens", 0) or 0) + (p2.get("cache_write_tokens", 0) or 0),
+            "patch_lines": len((p2.get("patch", "") or "").splitlines()),
+            "plan_lines": len((p1.get("patch", "") or "").splitlines()),
+            "error": p2.get("error") or p1.get("error"),
+            "phase1_cost": p1.get("cost", 0),
+            "phase2_cost": p2.get("cost", 0),
+            "phase1_steps": p1.get("steps", 0),
+            "phase2_steps": p2.get("steps", 0),
+        }
+
+    total_cost = phase1["total_cost"] + phase2["total_cost"]
+    total_steps = phase1["total_steps"] + phase2["total_steps"]
+
+    result_data = {
+        "repo": repo_name,
+        "task_id": task_id,
+        "features": sorted_features,
+        "setting": "plan_execute",
+        "run_id": run_id,
+        "run_name": run_name,
+        "agent_framework": agent_name,
+        "model": model_name,
+        "started_at": start_time.isoformat(),
+        "ended_at": end_time.isoformat(),
+        "duration_seconds": duration,
+        "agents": {agent_id: combined_agent(agent_id) for agent_id in agents},
+        "total_cost": total_cost,
+        "total_steps": total_steps,
+        "messages_sent": len(phase2["conversation"]),
+        "phase1_messages_sent": len(phase1["conversation"]),
+        "log_dir": str(pair_log_dir),
+    }
+
+    pair_log_dir.mkdir(parents=True, exist_ok=True)
+    with open(result_file, "w") as f:
+        json.dump(result_data, f, indent=2)
+
+    return {
+        "results": p2_results,
+        "total_cost": total_cost,
+        "total_steps": total_steps,
+        "duration": duration,
+        "run_id": run_id,
+        "log_dir": str(pair_log_dir),
+    }
+
+
+def _write_phase_result(
+    *,
+    log_dir: Path,
+    phase_name: str,
+    repo_name: str,
+    task_id: int,
+    sorted_features: list[int],
+    run_id: str,
+    run_name: str,
+    agent_name: str,
+    model_name: str,
+    phase: dict,
+) -> None:
+    """Per-phase result.json so each phase's cost / steps / statuses are
+    introspectable on disk without parsing the top-level combined result."""
+    log_dir.mkdir(parents=True, exist_ok=True)
+    results = phase["results"]
+    data = {
+        "repo": repo_name,
+        "task_id": task_id,
+        "features": sorted_features,
+        "setting": "plan_execute",
+        "phase": phase_name,
+        "run_id": run_id,
+        "run_name": run_name,
+        "agent_framework": agent_name,
+        "model": model_name,
+        "agents": {
+            agent_id: {
+                "feature_id": r.get("feature_id"),
+                "status": r.get("status"),
+                "cost": r.get("cost", 0),
+                "steps": r.get("steps", 0),
+                "input_tokens": r.get("input_tokens", 0),
+                "output_tokens": r.get("output_tokens", 0),
+                "cache_read_tokens": r.get("cache_read_tokens", 0),
+                "cache_write_tokens": r.get("cache_write_tokens", 0),
+                "artifact_lines": len((r.get("patch", "") or "").splitlines()),
+                "error": r.get("error"),
+            }
+            for agent_id, r in results.items()
+        },
+        "total_cost": phase["total_cost"],
+        "total_steps": phase["total_steps"],
+        "messages_sent": len(phase["conversation"]),
+    }
+    with open(log_dir / "result.json", "w") as f:
+        json.dump(data, f, indent=2)


### PR DESCRIPTION
## Summary

Adds `--setting plan_execute`: a two-phase variant of coop where agents first **plan** (coordinating via messaging + git, writing free-form `plan.txt` files) and then a **fresh set of executor agents** runs against each agent's own plan verbatim — no feature spec, no teammate plan, no Phase 1 conversation log.

The Phase 1 prompt explicitly frames the goal as *"produce a plan such that your patches don't merge-conflict"*, making coordination the load-bearing skill being tested. Phase 2 keeps the full coop toolset (messaging + git stay on) so we measure whether good plans are enough or whether mid-execute coordination still matters.

Stacked on #69 (the docker backend + `patch.txt` flow this builds on).

## What's new

- `runner/plan_execute.py` — new orchestrator. Shared infra setup → Phase 1 with `submission_artifact = plan.txt` → Phase 2 with each agent's plan as task → eval against Phase 2 patches.
- `runner/coop.py` — `_run_pair_phase()` + `setup_pair_infra()` extracted. `execute_coop()` composes them once, `execute_plan_execute()` composes them twice. `_spawn_agent()` gained `task_override` / `extra_config` / `log_dir_override` / `setting_subdir` kwargs.
- `agents/openhands_agent_sdk/adapter.py` — `_plan_submission_instructions(is_coop)` helper + config-based `submission_template` / `submission_artifact` overrides so the same adapter handles both phases.
- `cli.py`, `runner/core.py` — `plan_execute` setting wired into CLI + dispatch.
- `eval/runs.py`, `eval/evaluate.py` — discover `plan_execute/` log dirs, treat the setting like coop for eval (two patches, merge, test).

## Log layout

```
logs/<run>/plan_execute/<repo>/<task>/<pair>/
  phase1/
    agent1.plan, agent2.plan, agent*_traj.json, conversation.json, result.json
  agent1.patch, agent2.patch       # phase 2 at canonical path → auto-eval works as-is
  agent*_traj.json, conversation.json
  result.json                       # rolled-up cost/steps + phase 2 statuses
  eval.json
```

## Test plan

- [x] CI green (ruff / format / mypy / pytest — 385 pass, 63 skip)
- [x] Smoke on `llama_index_task/18813 [1,2]`: phase 1 produced a coordinated plan with explicit scope split (*"Teammate (agent2) will handle AudioBlock.resolve_audio…"*), 8 inter-agent messages. Phase 2 trajectory verified to contain ONLY the plan (feature.md title strings absent). Both patches applied, merge clean, eval ran end-to-end.
- [ ] Full 50-pair `flash` subset run is in flight; will post per-pair comparison against #69's baseline (50/50 Submitted, 9 both_passed = 18%) when it completes.

## Scope limit (v1)

Only `openhands_sdk` is supported. CLI rejects other adapters with a clear `NotImplementedError`. mini_swe_agent_v2 etc. would need to honour the same `config["submission_template"]` and `config["submission_artifact"]` overrides.
