### PR TITLE
feat(coop): optional "trust your teammate" prompt emphasis (openhands)

### DIFF
--- a/src/cooperbench/agents/openhands_agent_sdk/openhands-tools/openhands/tools/preset/default.py
+++ b/src/cooperbench/agents/openhands_agent_sdk/openhands-tools/openhands/tools/preset/default.py
@@ -1,5 +1,7 @@
 """Default preset configuration for OpenHands agents."""
 
+import os
+
 from openhands.sdk import Agent
 from openhands.sdk.context.condenser import (
     LLMSummarizingCondenser,
@@ -116,6 +118,20 @@ Teammates' branches are at `team/<name>` (e.g., `team/{teammate_name}`).
 * Push: `git push team {agent_id}`
 * Fetch: `git fetch team`
 """
+    # Experiment knob: when CB_COOP_TRUST_EMPHASIS is set, add a strong
+    # instruction to trust the teammate's stated promises (rather than
+    # re-verifying or defensively duplicating their work).  Off by default
+    # so the baseline coop prompt is unchanged.
+    if os.environ.get("CB_COOP_TRUST_EMPHASIS"):
+        collab_section += (
+            "\n## Trust\n"
+            "YOU SHOULD TRY TO TRUST YOUR TEAMMATE REGARDING WHAT THEY PROMISED. "
+            f"When {teammate_name} tells you which files/functions they will handle or how an "
+            "interface will behave, take them at their word: build against what they promised, "
+            "do not re-implement or second-guess their part, and do not duplicate their changes. "
+            "Coordinate through messages and rely on their commitments.\n"
+        )
+
     collab_section += """
 </collaboration>
 """


### PR DESCRIPTION
## What

An env-gated experiment knob, `CB_COOP_TRUST_EMPHASIS`. When set, the openhands coop collaboration system prompt gains a **Trust** block:

> YOU SHOULD TRY TO TRUST YOUR TEAMMATE REGARDING WHAT THEY PROMISED. … build against what they promised, do not re-implement or second-guess their part, and do not duplicate their changes.

Off by default — the baseline coop prompt is unchanged. Built host-side in `get_coop_system_prompt`, so it composes with whatever else is in the collaboration block.

## Result (flash, coop+git, gemini-3-flash, openhands)

| prompt | pass | merge-conflicts |
|---|---|---|
| baseline | 20% (10/50) | 18 |
| **+ trust emphasis** | **32% (16/50)** | **11** |

The lift came mainly from fewer merge conflicts — agents stopped redoing each other's work once told to trust stated promises. (Small countervailing cost: a few more apply-failures from building against an interface that didn't land exactly.) Coordination volume was unchanged (~9 msgs/pair).

## Test

`ruff` + `mypy` clean; full `pytest` suite (385 passed). The knob is openhands-only for now.
