### PR TITLE
agent: optional exact token-ID capture for token-level training

### DIFF
--- a/src/cooperbench/__about__.py
+++ b/src/cooperbench/__about__.py
@@ -1,3 +1,3 @@
 """Version information for CooperBench."""
 
-__version__ = "0.0.19"
+__version__ = "0.0.20"

--- a/src/cooperbench/agents/README.md
+++ b/src/cooperbench/agents/README.md
@@ -44,6 +44,7 @@ External packages can register custom agent implementations using the `COOPERBEN
 from cooperbench.agents.registry import register
 from cooperbench.agents import AgentResult
 
+
 @register("my_custom_agent")
 class CustomAgentRunner:
     def run(self, task, image, **kwargs) -> AgentResult:
@@ -76,15 +77,18 @@ All agents must implement the `AgentRunner` protocol:
 from dataclasses import dataclass
 from typing import Protocol
 
+
 @dataclass
 class AgentResult:
     """Result from an agent run."""
-    status: str           # "Submitted", "Error", "LimitsExceeded"
-    patch: str            # Generated diff/patch
-    cost: float           # Total LLM cost in USD
-    steps: int            # Number of agent steps/actions
+
+    status: str  # "Submitted", "Error", "LimitsExceeded"
+    patch: str  # Generated diff/patch
+    cost: float  # Total LLM cost in USD
+    steps: int  # Number of agent steps/actions
     messages: list[dict]  # Conversation history
-    error: str | None     # Error message if failed
+    error: str | None  # Error message if failed
+
 
 class AgentRunner(Protocol):
     """Protocol for agent framework adapters."""
@@ -102,8 +106,7 @@ class AgentRunner(Protocol):
         git_enabled: bool = False,
         messaging_enabled: bool = True,
         config: dict | None = None,
-    ) -> AgentResult:
-        ...
+    ) -> AgentResult: ...
 ```
 
 ## Adding a New Agent
@@ -125,6 +128,7 @@ agents/
 
 from cooperbench.agents import AgentResult
 from cooperbench.agents.registry import register
+
 
 @register("my_agent")
 class MyAgentRunner:

--- a/src/cooperbench/agents/mini_swe_agent_v2/models/litellm_model.py
+++ b/src/cooperbench/agents/mini_swe_agent_v2/models/litellm_model.py
@@ -43,6 +43,66 @@ class LitellmModelConfig(BaseModel):
     """Template used to render the observation after executing an action."""
     multimodal_regex: str = ""
     """Regex to extract multimodal content. Empty string disables multimodal processing."""
+    capture_token_ids: bool = False
+    """Record the exact prompt/response token IDs the inference server used.
+
+    When True, requests carry ``extra_body={"return_token_ids": true}`` so vLLM (>=0.10.2) /
+    SGLang return ``prompt_token_ids`` and ``token_ids`` alongside the usual response. They are
+    stored on each assistant message as ``extra["token_capture"]`` and persist into the saved
+    trajectory.
+
+    This exists for token-level training (distillation, TITO-style SFT), where re-tokenizing a
+    trajectory afterwards is not equivalent: BPE is non-injective, tool-call serialization can
+    differ between inference and training, and under context compaction the prompt a turn
+    actually saw no longer exists in the final message list. Capturing at request time makes
+    the training input identical to what the model saw, by construction.
+
+    Off by default; it only adds response payload when explicitly enabled.
+    """
+
+
+def _with_return_token_ids(kwargs: dict[str, Any]) -> dict[str, Any]:
+    """Add ``return_token_ids`` to the request's ``extra_body`` without clobbering it.
+
+    ``extra_body`` is how litellm forwards non-OpenAI fields to the backend, and callers may
+    already be using it, so merge rather than replace.
+    """
+    merged = dict(kwargs)
+    extra_body = dict(merged.get("extra_body") or {})
+    extra_body.setdefault("return_token_ids", True)
+    merged["extra_body"] = extra_body
+    return merged
+
+
+def _extract_token_capture(response: Any) -> dict[str, list[int]] | None:
+    """Pull prompt/output token ids out of a response, or None if the server did not send them.
+
+    Servers differ on placement: vLLM puts ``prompt_token_ids`` on the response and
+    ``token_ids`` on the choice, and some versions nest both under the choice. Check each
+    known location rather than assuming one.
+    """
+    try:
+        dumped = response.model_dump()
+    except AttributeError:
+        return None
+    choice = (dumped.get("choices") or [{}])[0]
+
+    prompt_ids = dumped.get("prompt_token_ids") or choice.get("prompt_token_ids")
+    output_ids = (
+        choice.get("token_ids")
+        or choice.get("output_token_ids")
+        or (choice.get("message") or {}).get("token_ids")
+    )
+
+    def _clean(ids: Any) -> list[int] | None:
+        if isinstance(ids, list) and ids and all(isinstance(i, int) for i in ids):
+            return ids
+        return None
+
+    prompt_ids, output_ids = _clean(prompt_ids), _clean(output_ids)
+    if prompt_ids is None or output_ids is None:
+        return None
+    return {"prompt_token_ids": prompt_ids, "output_token_ids": output_ids}
 
 
 class LitellmModel:
@@ -62,12 +122,15 @@ class LitellmModel:
             litellm.utils.register_model(json.loads(Path(self.config.litellm_model_registry).read_text()))
 
     def _query(self, messages: list[dict[str, str]], **kwargs):
+        merged = self.config.model_kwargs | kwargs
+        if self.config.capture_token_ids:
+            merged = _with_return_token_ids(merged)
         try:
             return litellm.completion(
                 model=self.config.model_name,
                 messages=messages,
                 tools=self._tools,
-                **(self.config.model_kwargs | kwargs),
+                **merged,
             )
         except litellm.exceptions.AuthenticationError as e:
             e.message += " You can permanently set your API key with `mini-extra config set KEY VALUE`."
@@ -91,6 +154,17 @@ class LitellmModel:
             **cost_output,
             "timestamp": time.time(),
         }
+        if self.config.capture_token_ids:
+            capture = _extract_token_capture(response)
+            if capture is None:
+                # Loud, because a silently empty capture only shows up much later as a
+                # training set with no usable rows.
+                logger.warning(
+                    "capture_token_ids is set but the server returned no token ids; "
+                    "vLLM >=0.10.2 or SGLang with return_token_ids support is required"
+                )
+            else:
+                message["extra"]["token_capture"] = capture
         return message
 
     def _calculate_cost(self, response) -> dict[str, float]:

--- a/src/cooperbench/agents/mini_swe_agent_v2/models/litellm_model.py
+++ b/src/cooperbench/agents/mini_swe_agent_v2/models/litellm_model.py
@@ -89,9 +89,7 @@ def _extract_token_capture(response: Any) -> dict[str, list[int]] | None:
 
     prompt_ids = dumped.get("prompt_token_ids") or choice.get("prompt_token_ids")
     output_ids = (
-        choice.get("token_ids")
-        or choice.get("output_token_ids")
-        or (choice.get("message") or {}).get("token_ids")
+        choice.get("token_ids") or choice.get("output_token_ids") or (choice.get("message") or {}).get("token_ids")
     )
 
     def _clean(ids: Any) -> list[int] | None:


### PR DESCRIPTION
Adds an opt-in `capture_token_ids` flag to `LitellmModelConfig`. Off by default — existing runs are byte-identical.

## Why

Token-level training (on-policy distillation, TITO-style SFT) needs the tokens the model *actually saw*. Reconstructing them afterwards by re-tokenizing a finished trajectory is not equivalent:

- BPE is non-injective (`HAVING` can tokenize as `H+AVING` or `HAV+ING`)
- tool-call serialization can differ between inference and training (whitespace, JSON key order)
- under context compaction, the prompt a turn saw **no longer exists** in the final message list

Capturing at request time makes the training input identical to the inference input by construction.

Concretely: a scan of a 10-pair `flash_10` run found **1942 assistant turns and zero usable states**, because there was no way to record ids.

## What it does

With `capture_token_ids: true`, requests carry `extra_body={"return_token_ids": true}` and the returned ids land on each assistant message as:

```python
message["extra"]["token_capture"] = {"prompt_token_ids": [...], "output_token_ids": [...]}
```

which persists into the saved trajectory.

Details worth noting:

- `_with_return_token_ids` **merges** into any existing `extra_body` instead of replacing it.
- `_extract_token_capture` handles both placements seen in practice — vLLM puts `prompt_token_ids` on the response and `token_ids` on the choice; some versions nest both under the choice — and returns `None` rather than partial data.
- A server that ignores the flag logs a warning. Silently returning no ids otherwise surfaces much later as a training set with zero usable rows.
- The summarizer path is deliberately **not** captured; those turns are excluded from training anyway.

## Testing

`tests/agents`: **121 passed**. The 2 failures in `test_team_wiring.py` are a missing optional `openhands.tools.task_tracker.coop_definition` module and reproduce on clean `main`.

Verified directly:

```
capture_token_ids default: False
settable via config      : True
extra_body merge         : {'extra_body': {'a': 1, 'return_token_ids': True}}
capture extraction       : {'prompt_token_ids': [1, 2], 'output_token_ids': [3]}
```

plus both response placements, missing ids, and empty-list ids (all correctly rejected).

Requires vLLM >= 0.10.2 or SGLang with `return_token_ids` support. Bumps version to 0.0.20.