### PR TITLE
agent: read token ids from provider_specific_fields (0.0.20 captured nothing)

### DIFF
--- a/src/cooperbench/__about__.py
+++ b/src/cooperbench/__about__.py
@@ -1,3 +1,3 @@
 """Version information for CooperBench."""
 
-__version__ = "0.0.20"
+__version__ = "0.0.21"

--- a/src/cooperbench/agents/mini_swe_agent_v2/models/litellm_model.py
+++ b/src/cooperbench/agents/mini_swe_agent_v2/models/litellm_model.py
@@ -78,18 +78,31 @@ def _extract_token_capture(response: Any) -> dict[str, list[int]] | None:
     """Pull prompt/output token ids out of a response, or None if the server did not send them.
 
     Servers differ on placement: vLLM puts ``prompt_token_ids`` on the response and
-    ``token_ids`` on the choice, and some versions nest both under the choice. Check each
-    known location rather than assuming one.
+    ``token_ids`` on the choice, and some versions nest both under the choice.
+
+    litellm adds a third location. It rebuilds every response into its own model, keeping only
+    fields it knows about; top-level extras survive on ``ModelResponse``, but anything extra on
+    a *choice* is swept into ``provider_specific_fields`` by ``convert_to_model_response_object``.
+    That is where vLLM's per-choice ``token_ids`` actually ends up, so checking only the raw key
+    silently yields nothing and every turn looks uncaptured.
+
+    Note this requires an OpenAI-style provider prefix. litellm's Anthropic path builds its
+    response through a different transform that discards these fields entirely.
     """
     try:
         dumped = response.model_dump()
     except AttributeError:
         return None
     choice = (dumped.get("choices") or [{}])[0]
+    psf = choice.get("provider_specific_fields") or {}
 
-    prompt_ids = dumped.get("prompt_token_ids") or choice.get("prompt_token_ids")
+    prompt_ids = dumped.get("prompt_token_ids") or choice.get("prompt_token_ids") or psf.get("prompt_token_ids")
     output_ids = (
-        choice.get("token_ids") or choice.get("output_token_ids") or (choice.get("message") or {}).get("token_ids")
+        choice.get("token_ids")
+        or choice.get("output_token_ids")
+        or psf.get("token_ids")
+        or psf.get("output_token_ids")
+        or (choice.get("message") or {}).get("token_ids")
     )
 
     def _clean(ids: Any) -> list[int] | None:


### PR DESCRIPTION
Follow-up to #77. **0.0.20's `capture_token_ids` never actually produced a capture.**

A live 10-pair run logged `capture_token_ids is set but the server returned no token ids` on **all 816 calls** — while the server was returning them the whole time. Confirmed by curling the endpoint directly:

```
top keys : [..., 'prompt_token_ids', 'prompt_logprobs', ...]
choice   : ['finish_reason', 'index', 'logprobs', 'message', 'stop_reason', 'token_ids']
```

## Root cause

litellm rebuilds every response into its own model. Top-level extras survive on `ModelResponse` (which is why `prompt_token_ids` came through), but extras on a **choice** are swept into `provider_specific_fields` by `convert_to_model_response_object`:

```python
provider_specific_fields = {}
for field in choice.keys():
    if field not in Choices.model_fields.keys():
        provider_specific_fields[field] = choice[field]
choice = Choices(..., provider_specific_fields=provider_specific_fields)
```

vLLM's per-choice `token_ids` lands there. Reading only the raw key yields nothing, every turn looks uncaptured, and the failure surfaces much later as an empty training set.

## Also: the provider prefix matters

Measured against a live vLLM endpoint:

| prefix | `prompt_token_ids` | `token_ids` |
|---|---|---|
| `anthropic/` | dropped | dropped |
| `openai/` | kept | via `provider_specific_fields` |

litellm's Anthropic path uses a different transform that discards both outright. Now documented on the function, since `anthropic/<model>` is a common way to point litellm at a custom OpenAI-compatible `base_url`.

## Verification

Ran a vLLM-shaped payload through litellm's own `convert_to_model_response_object` and extracted both id lists back out:

```
REAL litellm-transformed response -> {'prompt_token_ids': [11, 22, 33], 'output_token_ids': [44, 55]}
```

`tests/agents`: 121 passed. The 2 `test_team_wiring.py` failures are the missing optional `openhands` module and reproduce on clean main.

Bumps to 0.0.21.