### PR TITLE
agent: coop agents could not tell a finished peer from a silent one

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,36 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.0.22] - 2026-08-04
+
+### Fixed
+
+- **A coop agent that finished could not be distinguished from one that was ignoring you.** When an agent submitted and exited, its peer kept talking to a mailbox nobody would ever read again: `MessagingConnector.send` queued into Redis and returned success unconditionally, with no liveness check. Measured over 8 `flash_10` pairs, **16 messages sent / 11 delivered (31% lost)**; in `pallets_click_task/2800/f1_f7` all 3 were lost — sent 35s after the peer's final turn. The sender was told `Message sent to agent2` (returncode 0) each time, and its own summary recorded *"Coordination with agent2 is ongoing … no expected conflicts"* immediately before submitting a patch that merge-conflicted. `send()` now returns `False` for a departed peer and the agent receives a non-zero result naming the cause and the recovery path, rather than a false success.
+
+- **`send_message --wait` was documented but never implemented.** `DefaultAgent._handle_send_message` guarded on `hasattr(self.comm, "send_and_wait")`, and `MessagingConnector` had no such method — so `--wait` silently degraded to fire-and-forget. Agents asking a blocking question got an instant "Message sent" and moved on. `send_and_wait(recipient, content, timeout)` now exists, returns `(delivered, replies)`, and ends the wait as soon as the peer replies **or exits**, instead of burning the full 60s on a reply that cannot arrive.
+
+- **`team/<peer>` never contained the peer's work.** `GitConnector.setup` pushes the base commit once and nothing updates the branch afterwards, while the prompt presents that remote as the sanctioned way to see a colleague's code. Across 19 agent runs there were **zero pushes**: in one pair an agent ran 24 `git fetch` / `git diff team/agent2` commands and saw the untouched baseline every time, then asked its colleague "have you submitted your branch yet?". Each agent now publishes its **submitted patch** (`patch.txt`, the artifact that is actually evaluated — not the working tree, which may differ) to `team/<agent_id>` on exit. It is built in a detached worktree from the pristine base, so the agent's own branch, index and working tree are untouched and a patch is never double-applied when the agent had already committed its work.
+
+### Added
+
+- Peers are told once, in context, when a colleague finishes: `[agent2 has completed their work and exited]`, with the branch to reconcile against. Publication is best-effort, so the exit marker records whether the patch actually reached the remote and the agent is only pointed at that branch when it really holds their submission.
+
+### Changed
+
+- The coop prompt now states what `team/<peer>` holds and when ("stays at the repository's starting state until your colleague submits" — an empty diff early means *not submitted yet*, not *no changes*), that `--wait` can return early, and that a colleague may exit before you do.
+
+## [0.0.21] - 2026-08-04
+
+### Fixed
+
+- **`capture_token_ids` (0.0.20) never produced a capture.** litellm rebuilds each response into its own model; top-level extras survive on `ModelResponse`, but extras on a *choice* are swept into `provider_specific_fields` by `convert_to_model_response_object` — which is where vLLM's per-choice `token_ids` lands. Reading the raw key yielded nothing, and a live run logged the "server returned no token ids" warning on all 816 calls while the server was returning them the whole time. Also documents that this requires an OpenAI-style provider prefix: litellm's Anthropic path uses a different transform that discards both `prompt_token_ids` and `token_ids` outright.
+
+## [0.0.20] - 2026-08-04
+
+### Added
+
+- **Optional `capture_token_ids` on `LitellmModelConfig`** (default `False`, so existing runs are byte-identical). When set, requests carry `extra_body={"return_token_ids": true}` and the ids the server actually used are stored on each assistant message as `extra["token_capture"]`, persisting into the saved trajectory. Reconstructing them afterwards is not equivalent: BPE is non-injective, tool-call serialization can differ between inference and training, and under context compaction the prompt a turn saw no longer exists in the final message list. Requires vLLM >= 0.10.2 or SGLang with `return_token_ids` support.
+
 ## [0.0.19] - 2026-05-25
 
 ### Fixed

--- a/src/cooperbench/__about__.py
+++ b/src/cooperbench/__about__.py
@@ -1,3 +1,3 @@
 """Version information for CooperBench."""
 
-__version__ = "0.0.21"
+__version__ = "0.0.22"

--- a/src/cooperbench/agents/mini_swe_agent_v2/agents/default.py
+++ b/src/cooperbench/agents/mini_swe_agent_v2/agents/default.py
@@ -16,6 +16,10 @@ from cooperbench.agents.mini_swe_agent_v2.connectors.messaging import MessagingC
 from cooperbench.agents.mini_swe_agent_v2.exceptions import InterruptAgentFlow, LimitsExceeded
 from cooperbench.agents.mini_swe_agent_v2.utils.serialize import recursive_merge
 
+# Name of the shared git remote created by GitConnector.  Referenced in the messages the
+# agent sees, so it must match GitConnector.REMOTE_NAME.
+GIT_REMOTE = "team"
+
 
 class AgentConfig(BaseModel):
     """Check the config files in config/ for example settings."""
@@ -197,8 +201,73 @@ class DefaultAgent:
             finally:
                 self.save(self.config.output_path)
             if self.messages[-1].get("role") == "exit":
+                published = self._publish_final_work()
+                if self.comm:
+                    self.comm.mark_exited(published=published)
                 break
         return self.messages[-1].get("extra", {})
+
+    def _publish_final_work(self) -> bool:
+        """Publish this agent's *submitted patch* to the shared remote before exiting.
+
+        The remote is seeded with the base commit at setup and never updated again, so a
+        peer inspecting ``{GIT_REMOTE}/<agent>`` sees the untouched baseline no matter how
+        much work was done — and reasonably concludes their colleague has not started.
+        The prompt presents that remote as the sanctioned way to see a colleague's code,
+        so today it is a documented capability that silently returns nothing.
+
+        We publish ``patch.txt``, not the working tree: patch.txt is the artifact that
+        gets evaluated and merged, and agents are free to submit a subset of their edits.
+        Showing a peer the tree would show them something other than what will be merged.
+
+        Built in a detached worktree so the agent's own branch, index and working tree
+        are untouched — the adapter still reads patch.txt from the container afterwards.
+
+        Returns True only when the patch actually reached the remote.  Peers are told to
+        read that branch, so a failed publication must not be reported as a success.
+        Best-effort otherwise: publication must never fail a run.
+        """
+        if not getattr(self, "comm", None):
+            return False  # solo run: nobody to publish to
+        agent_id = self.comm.agent_id
+        script = (
+            "set -e; "
+            # the repo is normally /workspace/repo, but fall back rather than guess
+            'repo=/workspace/repo; [ -d "$repo/.git" ] || repo=/workspace; cd "$repo"; '
+            # No patch means nothing to publish.  Exit non-zero so this is NOT reported as
+            # a successful publication -- claiming the branch holds their submission when
+            # it holds the baseline is the exact failure this change removes.
+            'test -s patch.txt || { echo "no patch.txt to publish"; exit 3; }; '
+            # Branch from the pristine base, not from HEAD: the evaluator applies patch.txt
+            # to the base, so mirroring that is what makes the branch equal the submission.
+            # If the agent committed its work, HEAD already contains it and applying the
+            # patch on top would double-apply.  setup() seeds the remote's main with base.
+            f"git fetch -q {GIT_REMOTE} 2>/dev/null || true; "
+            f"base=$(git rev-parse {GIT_REMOTE}/main 2>/dev/null "
+            "|| git rev-parse main 2>/dev/null || git rev-parse HEAD); "
+            'tmp=$(mktemp -d); git worktree add -q --detach "$tmp" "$base"; '
+            'cp patch.txt "$tmp/.__submitted.patch"; cd "$tmp"; '
+            "git apply --ignore-whitespace .__submitted.patch || git apply --3way .__submitted.patch; "
+            "rm -f .__submitted.patch; git add -A; "
+            f"git -c user.email=agent@cooperbench -c user.name={agent_id} "
+            f'commit -q --allow-empty -m "submitted work by {agent_id}"; '
+            f"git push -q -f {GIT_REMOTE} HEAD:refs/heads/{agent_id}; "
+            # `worktree remove` matches on git's own resolved path, which differs from
+            # $tmp wherever the temp dir sits behind a symlink; deleting the directory and
+            # pruning is equivalent and does not depend on that matching.
+            'cd /; rm -rf "$tmp"; git -C "$repo" worktree prune 2>/dev/null || true'
+        )
+        try:
+            result = self.env.execute({"command": script})
+            if (result or {}).get("returncode") == 0:
+                self.log(f"PUBLISHED submitted patch to {GIT_REMOTE}/{agent_id}")
+                return True
+            self.logger.warning(
+                f"could not publish to {GIT_REMOTE}/{agent_id}: {(result or {}).get('output', '')[:300]}"
+            )
+        except Exception as e:  # noqa: BLE001 - never fail a run over publication
+            self.logger.warning(f"could not publish to {GIT_REMOTE}/{agent_id}: {e}")
+        return False
 
     def step(self) -> list[dict]:
         """Query the LM, execute actions. Polls for inter-agent messages
@@ -215,6 +284,7 @@ class DefaultAgent:
                         content=f"[Message from {msg['from']}]: {msg['content']}",
                     )
                 )
+            self._announce_departed_peers()
         # In team mode, also refresh the shared task list so the LLM
         # sees the live state of who's working on what before its next
         # response.  ``team_poller`` is set by the adapter when team
@@ -351,30 +421,110 @@ class DefaultAgent:
             outputs.append(self.env.execute(action))
         return self.add_messages(*self.model.format_observation_messages(message, outputs, self.get_template_vars()))
 
+    def _announce_departed_peers(self) -> None:
+        """Tell the agent, once, when a peer has finished and left.
+
+        Otherwise an agent can spend the rest of its run waiting for an answer from a
+        colleague who is no longer running, with nothing in its context to indicate that.
+        Announced once per peer; the recovery path is named because the peer's work is
+        still reachable through git even though the conversation is over.
+        """
+        if not self.comm:
+            return
+        announced = getattr(self, "_departed_announced", None)
+        if announced is None:
+            announced = self._departed_announced = set()
+        for peer in getattr(self.comm, "agents", []) or []:
+            if peer == self.comm.agent_id or peer in announced:
+                continue
+            if not self.comm.has_exited(peer):
+                continue
+            announced.add(peer)
+            self.log(f"PEER EXITED: {peer}")
+            self.add_messages(
+                self.model.format_message(
+                    role="user",
+                    content=(
+                        f"[{peer} has completed their work and exited] They will not read or "
+                        f"answer further messages.\n\n{self._peer_work_pointer(peer)}"
+                    ),
+                )
+            )
+
+    def _peer_work_pointer(self, peer: str) -> str:
+        """Where to find a departed peer's work — only claimed when it is really there.
+
+        Publication to the shared remote is best-effort, so asserting the branch holds
+        their submission when it does not would repeat exactly the failure this whole
+        change exists to remove: telling the agent something untrue and letting it act
+        on it.
+        """
+        if self.comm and self.comm.has_published(peer):
+            return (
+                f"Their submitted patch is on branch {GIT_REMOTE}/{peer}. If your changes "
+                f"overlap theirs, inspect and reconcile before you submit:\n"
+                f"    git fetch {GIT_REMOTE} && git diff HEAD...{GIT_REMOTE}/{peer}"
+            )
+        return (
+            f"Their work could NOT be published to {GIT_REMOTE}/{peer}, so that branch does "
+            f"not reflect what they submitted — do not rely on it. Proceed on your own "
+            f"judgement and keep your changes as self-contained as you can."
+        )
+
     def _handle_send_message(self, action: dict) -> dict:
         """Handle a send_message call via the messaging connector.
 
-        ``wait=True`` (when the agent wrote ``send_message --wait ...`` in
-        bash) uses ``send_and_wait`` so the peer's reply comes back in the
-        same tool output.
+        ``wait=True`` (when the agent wrote ``send_message --wait ...`` in bash) blocks
+        until the peer replies, the peer exits, or the timeout elapses.
+
+        A send to a peer that has already finished is reported as a failure, not a
+        success.  Reporting success there is actively misleading: the agent believes it
+        has coordinated, keeps waiting for an answer that cannot arrive, and ships work
+        that was never reconciled.
         """
         recipient = action.get("recipient", "")
         content = action.get("content", "")
         wait = action.get("wait", False)
 
         if wait and hasattr(self.comm, "send_and_wait"):
-            replies = self.comm.send_and_wait(recipient, content, timeout=60)
+            delivered, replies = self.comm.send_and_wait(recipient, content, timeout=60)
+            if not delivered:
+                return self._peer_gone_result(recipient)
             self.log(f"SENT (blocking) to {recipient}: {content[:80]}...")
             self.sent_messages.append({"to": recipient, "content": content})
             output = f"Message sent to {recipient}"
-            for r in replies or []:
-                output += f"\n\n[Reply from {r['from']}]: {r['content']}"
+            if replies:
+                for r in replies:
+                    output += f"\n\n[Reply from {r['from']}]: {r['content']}"
+            elif self.comm.has_exited(recipient):
+                output += (
+                    f"\n\nNo reply: {recipient} has since completed their work and exited.\n"
+                    f"{self._peer_work_pointer(recipient)}"
+                )
             return {"output": output, "returncode": 0, "exception_info": ""}
 
-        self.comm.send(recipient, content)
+        if not self.comm.send(recipient, content):
+            return self._peer_gone_result(recipient)
         self.log(f"SENT to {recipient}: {content[:80]}...")
         self.sent_messages.append({"to": recipient, "content": content})
         return {"output": f"Message sent to {recipient}", "returncode": 0, "exception_info": ""}
+
+    def _peer_gone_result(self, recipient: str) -> dict:
+        """Tell the agent its peer is gone, and what to do about it.
+
+        Phrased as a terminal state rather than a delivery error so the agent does not
+        retry, and names the recovery path so the peer's work is still reachable.
+        """
+        self.log(f"NOT DELIVERED to {recipient}: peer already exited")
+        return {
+            "output": (
+                f"{recipient} has already completed their work and exited. Your message was "
+                f"NOT delivered and no reply will come — do not send further messages to "
+                f"them.\n\n{self._peer_work_pointer(recipient)}"
+            ),
+            "returncode": 1,
+            "exception_info": "",
+        }
 
     def serialize(self, *extra_dicts) -> dict:
         """Serialize agent state to a json-compatible nested dictionary for saving."""

--- a/src/cooperbench/agents/mini_swe_agent_v2/config/coop.yaml
+++ b/src/cooperbench/agents/mini_swe_agent_v2/config/coop.yaml
@@ -50,17 +50,22 @@ agent:
     MSG
     ```
 
+    `--wait` returns as soon as they reply, or immediately if they have already finished — it does not always burn the full 60 seconds.
+
     Tips:
     - A `send_message` by itself is a valid tool call. You do not need to combine it with other commands.
     - You can freely choose `--wait` or regular `send_message` based on what the situation requires.
     - Messages from your colleague appear as: [Message from ...]: ...
     - IMPORTANT: Only the system delivers messages from your colleague. Never write `[Message from ...]` yourself.
+    - Your colleague may finish and exit before you do. When that happens you are told so explicitly, and any further `send_message` to them fails with a non-zero exit code instead of being silently discarded. Do not keep messaging or waiting after that — reconcile against their published branch and submit.
     {% endif %}
 
     {% if git_enabled %}
     ## Shared Git Remote (read-only)
 
     A shared remote called `team` lets you see your colleague's actual code changes. Use communication as your primary way to coordinate. Use git only to peek at your colleague's code in complex cases or to verify merging towards the end. Think about how experienced software engineers would make the most of direct communication and git at various stages — and do that.
+
+    **What that branch holds, and when.** `team/{{ agents | reject('equalto', agent_id) | first }}` stays at the repository's starting state until your colleague submits; their patch is published there automatically at that moment. So an empty diff early on means "they have not submitted yet" — it does NOT mean they have made no changes. Ask them directly rather than inferring from git. You are told explicitly when they finish.
 
     Your patches are merged automatically after you both submit. Do not merge, pull, or rebase their branch into yours, as the automatic merge will see duplicate changes and fail.
 

--- a/src/cooperbench/agents/mini_swe_agent_v2/connectors/messaging.py
+++ b/src/cooperbench/agents/mini_swe_agent_v2/connectors/messaging.py
@@ -21,6 +21,7 @@ Example:
 """
 
 import json
+import time
 from datetime import datetime
 from typing import Any
 
@@ -53,6 +54,45 @@ class MessagingConnector:
 
         # Clear stale messages from previous runs
         self._client.delete(self._inbox_key)
+        self._client.delete(self._exited_key(agent_id))
+
+    def _exited_key(self, agent_id: str) -> str:
+        return f"{self._prefix}{agent_id}:exited"
+
+    def mark_exited(self, published: bool = False) -> None:
+        """Record that this agent has finished, so peers stop waiting on it.
+
+        Without this a peer's ``send`` silently succeeds into an inbox nobody will ever
+        read again, and ``send_and_wait`` blocks for its full timeout on a reply that
+        cannot come.
+
+        ``published`` records whether this agent's submitted patch actually reached the
+        shared remote.  Peers are told to go read that branch, so they must only be told
+        that when it is true — publication is best-effort and can fail.
+        """
+        try:
+            self._client.set(self._exited_key(self.agent_id), "published" if published else "1")
+        except redis.RedisError:  # never let bookkeeping take down a run
+            pass
+
+    def has_exited(self, agent_id: str) -> bool:
+        """True when ``agent_id`` has finished its work and left."""
+        try:
+            return bool(self._client.exists(self._exited_key(agent_id)))
+        except redis.RedisError:
+            return False
+
+    def has_published(self, agent_id: str) -> bool:
+        """True when ``agent_id``'s submitted patch is actually on the shared remote."""
+        try:
+            raw = self._client.get(self._exited_key(agent_id))
+        except redis.RedisError:
+            return False
+        if raw is None:
+            return False
+        if isinstance(raw, bytes):
+            raw = raw.decode()
+        return raw == "published"
 
     def setup(self, env: Any) -> None:
         """Configure the agent's sandbox for messaging.
@@ -65,13 +105,20 @@ class MessagingConnector:
         """
         pass
 
-    def send(self, recipient: str, content: str) -> None:
+    def send(self, recipient: str, content: str) -> bool:
         """Send a message to another agent's inbox.
 
         Args:
             recipient: Target agent's ID
             content: Message content
+
+        Returns:
+            ``True`` if the message was queued, ``False`` if the recipient has already
+            finished and left — in which case nothing will ever read it.  Callers must
+            surface that to the agent instead of reporting success.
         """
+        if self.has_exited(recipient):
+            return False
         message = {
             "from": self.agent_id,
             "to": recipient,
@@ -79,6 +126,7 @@ class MessagingConnector:
             "timestamp": datetime.now().isoformat(),
         }
         self._client.rpush(f"{self._prefix}{recipient}:inbox", json.dumps(message))
+        return True
 
     def receive(self) -> list[dict]:
         """Get all pending messages from inbox (empties the inbox).
@@ -93,6 +141,28 @@ class MessagingConnector:
                 break
             messages.append(json.loads(msg))
         return messages
+
+    def send_and_wait(self, recipient: str, content: str, timeout: int = 60) -> tuple[bool, list[dict]]:
+        """Send, then block until the recipient replies, they exit, or ``timeout``.
+
+        Returns ``(delivered, replies)``.  ``delivered`` is False when the recipient had
+        already finished before the send.  The wait also ends the moment the recipient
+        exits, so an agent never burns the full timeout on a reply that cannot arrive.
+        """
+        if not self.send(recipient, content):
+            return False, []
+
+        deadline = time.monotonic() + timeout
+        replies: list[dict] = []
+        while time.monotonic() < deadline:
+            got = self.receive()
+            if got:
+                replies.extend(got)
+                break
+            if self.has_exited(recipient):
+                break
+            time.sleep(1.0)
+        return True, replies
 
     def broadcast(self, content: str) -> None:
         """Send a message to all other agents.

--- a/tests/agents/mini_swe_agent_v2/connectors/test_messaging.py
+++ b/tests/agents/mini_swe_agent_v2/connectors/test_messaging.py
@@ -112,3 +112,86 @@ class TestMessagingConnector:
             url=f"{redis_url}#namespace1",
         )
         assert conn_ns1_receiver.peek() == 0
+
+
+class TestPeerExit:
+    """A peer that finishes must stop looking like a live correspondent.
+
+    Before this, ``send`` to a departed agent returned success, the message sat unread
+    in Redis forever, and ``--wait`` blocked for its full timeout on a reply that could
+    never arrive.  Observed in a real run: one agent sent three messages (two blocking)
+    to a colleague that had already submitted, was told "Message sent" each time,
+    concluded coordination was "ongoing", and shipped a conflicting patch.
+    """
+
+    @pytest.fixture
+    def alice(self, redis_url):
+        return MessagingConnector(agent_id="agent1", agents=["agent1", "agent2"], url=f"{redis_url}#test:exit")
+
+    @pytest.fixture
+    def bob(self, redis_url):
+        return MessagingConnector(agent_id="agent2", agents=["agent1", "agent2"], url=f"{redis_url}#test:exit")
+
+    def test_send_to_live_peer_reports_delivered(self, alice, bob):
+        assert alice.send("agent2", "still here?") is True
+        assert len(bob.receive()) == 1
+
+    def test_send_to_exited_peer_reports_not_delivered(self, alice, bob):
+        bob.mark_exited()
+        assert alice.send("agent2", "are you there?") is False
+        assert bob.peek() == 0, "message must not be queued for an agent that has left"
+
+    def test_has_exited_tracks_state(self, alice, bob):
+        assert alice.has_exited("agent2") is False
+        bob.mark_exited()
+        assert alice.has_exited("agent2") is True
+
+    def test_published_flag_distinguishes_publish_success(self, alice, bob):
+        bob.mark_exited(published=False)
+        assert alice.has_exited("agent2") is True
+        assert alice.has_published("agent2") is False, (
+            "a failed publish must not be reported as work available on the remote"
+        )
+
+    def test_published_flag_set_when_publish_succeeded(self, alice, bob):
+        bob.mark_exited(published=True)
+        assert alice.has_published("agent2") is True
+
+    def test_send_and_wait_returns_immediately_when_peer_gone(self, alice, bob):
+        import time as _t
+
+        bob.mark_exited()
+        start = _t.monotonic()
+        delivered, replies = alice.send_and_wait("agent2", "hello?", timeout=60)
+        elapsed = _t.monotonic() - start
+        assert delivered is False
+        assert replies == []
+        assert elapsed < 5, f"must not block on a departed peer (took {elapsed:.1f}s)"
+
+    def test_send_and_wait_stops_when_peer_exits_mid_wait(self, alice, bob):
+        import threading
+        import time as _t
+
+        threading.Timer(1.0, bob.mark_exited).start()
+        start = _t.monotonic()
+        delivered, replies = alice.send_and_wait("agent2", "still working?", timeout=60)
+        elapsed = _t.monotonic() - start
+        assert delivered is True, "peer was alive at send time"
+        assert replies == []
+        assert elapsed < 10, f"must abandon the wait once the peer exits (took {elapsed:.1f}s)"
+
+    def test_send_and_wait_returns_reply(self, alice, bob):
+        import threading
+
+        threading.Timer(0.5, lambda: bob.send("agent1", "yes, editing core.py")).start()
+        delivered, replies = alice.send_and_wait("agent2", "what are you editing?", timeout=30)
+        assert delivered is True
+        assert len(replies) == 1
+        assert replies[0]["content"] == "yes, editing core.py"
+
+    def test_fresh_connector_clears_stale_exit_marker(self, redis_url):
+        first = MessagingConnector(agent_id="agent2", agents=["agent1", "agent2"], url=f"{redis_url}#test:stale")
+        first.mark_exited()
+        # a new run reuses the agent id; it must not start out looking departed
+        second = MessagingConnector(agent_id="agent2", agents=["agent1", "agent2"], url=f"{redis_url}#test:stale")
+        assert second.has_exited("agent2") is False

--- a/tests/agents/mini_swe_agent_v2/test_peer_exit_agent.py
+++ b/tests/agents/mini_swe_agent_v2/test_peer_exit_agent.py
@@ -1,0 +1,169 @@
+"""Agent-level behaviour when a coop peer finishes first.
+
+The connector tests cover the Redis layer. These cover what the *agent actually sees*,
+which is where the original bug lived: `send()` queued into a dead mailbox and
+`_handle_send_message` reported `returncode: 0, "Message sent to agent2"` regardless.
+An agent then recorded "coordination is ongoing" and submitted a conflicting patch.
+
+Driven directly rather than through a live rollout: whether an agent chooses to call
+send_message is up to the model, so a real run cannot be relied on to exercise the path.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from cooperbench.agents.mini_swe_agent_v2.agents.default import GIT_REMOTE, DefaultAgent
+from cooperbench.agents.mini_swe_agent_v2.connectors import MessagingConnector
+
+
+class _StubModel:
+    def format_message(self, role, content, extra=None):
+        return {"role": role, "content": content, "extra": extra or {}}
+
+    def get_template_vars(self):
+        return {}
+
+    def serialize(self):
+        return {}
+
+
+class _StubEnv:
+    def __init__(self):
+        self.commands = []
+
+    def execute(self, action):
+        self.commands.append(action)
+        return {"output": "", "returncode": 0}
+
+    def get_template_vars(self):
+        return {}
+
+    def serialize(self):
+        return {}
+
+
+def _agent(agent_id, comm):
+    return DefaultAgent(
+        _StubModel(),
+        _StubEnv(),
+        comm=comm,
+        agent_id=agent_id,
+        system_template="s",
+        instance_template="i",
+    )
+
+
+@pytest.fixture
+def pair(redis_url):
+    ns = f"{redis_url}#test:peerexit-agent"
+    a = MessagingConnector(agent_id="agent1", agents=["agent1", "agent2"], url=ns)
+    b = MessagingConnector(agent_id="agent2", agents=["agent1", "agent2"], url=ns)
+    return a, b
+
+
+class TestSendToDepartedPeer:
+    def test_reports_failure_not_success(self, pair):
+        """
+        Target:   DefaultAgent._handle_send_message
+        Expected: non-zero returncode, and text that says the peer finished
+        Catches:  the original bug -- "Message sent to agent2" with returncode 0 to an
+                  agent that had already exited, which the sender believed.
+        """
+        alice_comm, bob_comm = pair
+        bob_comm.mark_exited(published=True)
+        out = _agent("agent1", alice_comm)._handle_send_message(
+            {"recipient": "agent2", "content": "what files are you editing?"}
+        )
+        assert out["returncode"] == 1
+        assert "completed their work and exited" in out["output"]
+        assert "NOT delivered" in out["output"]
+
+    def test_points_at_the_branch_when_the_patch_was_published(self, pair):
+        alice_comm, bob_comm = pair
+        bob_comm.mark_exited(published=True)
+        out = _agent("agent1", alice_comm)._handle_send_message({"recipient": "agent2", "content": "hello"})
+        assert f"{GIT_REMOTE}/agent2" in out["output"]
+        assert "git fetch" in out["output"]
+
+    def test_does_not_point_at_the_branch_when_publication_failed(self, pair):
+        """
+        Expected: the agent is told the branch is NOT usable
+        Catches:  re-introducing the same class of lie -- publication is best-effort, so
+                  claiming the branch holds their submission when it does not would send
+                  the agent to read a baseline and treat it as their colleague's work.
+        """
+        alice_comm, bob_comm = pair
+        bob_comm.mark_exited(published=False)
+        out = _agent("agent1", alice_comm)._handle_send_message({"recipient": "agent2", "content": "hello"})
+        assert "could NOT be published" in out["output"]
+        assert "do not rely on it" in out["output"]
+
+    def test_live_peer_still_succeeds(self, pair):
+        alice_comm, _ = pair
+        out = _agent("agent1", alice_comm)._handle_send_message({"recipient": "agent2", "content": "still here?"})
+        assert out["returncode"] == 0
+        assert out["output"] == "Message sent to agent2"
+
+
+class TestDepartureAnnouncement:
+    def test_announced_once_with_recovery_path(self, pair):
+        """
+        Target:   DefaultAgent._announce_departed_peers
+        Expected: exactly one injected user turn naming the peer and the branch
+        Catches:  an agent waiting out the rest of its run on a colleague that is gone,
+                  with nothing in its context saying so; and repeated announcements
+                  flooding the context on every subsequent step.
+        """
+        alice_comm, bob_comm = pair
+        alice = _agent("agent1", alice_comm)
+        alice._announce_departed_peers()
+        assert alice.messages == [], "nothing to announce while the peer is running"
+
+        bob_comm.mark_exited(published=True)
+        alice._announce_departed_peers()
+        alice._announce_departed_peers()  # idempotent
+        notices = [m for m in alice.messages if "has completed their work and exited]" in m["content"]]
+        assert len(notices) == 1
+        assert f"{GIT_REMOTE}/agent2" in notices[0]["content"]
+
+    def test_solo_run_announces_nothing(self):
+        agent = DefaultAgent(
+            _StubModel(), _StubEnv(), comm=None, agent_id="agent1", system_template="s", instance_template="i"
+        )
+        agent._announce_departed_peers()
+        assert agent.messages == []
+
+
+class TestPublishFinalWork:
+    def test_solo_run_does_not_publish(self):
+        agent = DefaultAgent(
+            _StubModel(), _StubEnv(), comm=None, agent_id="agent1", system_template="s", instance_template="i"
+        )
+        assert agent._publish_final_work() is False
+
+    def test_publish_reports_failure_when_the_container_command_fails(self, pair):
+        """
+        Expected: False, so mark_exited(published=False) and peers are not misdirected
+        Catches:  treating a failed publish as success -- e.g. the `test -s patch.txt`
+                  guard exiting 0 when there is no patch, which would tell the peer the
+                  branch holds a submission that was never pushed.
+        """
+        alice_comm, _ = pair
+        agent = _agent("agent1", alice_comm)
+
+        class _FailingEnv(_StubEnv):
+            def execute(self, action):
+                return {"output": "no patch.txt to publish", "returncode": 3}
+
+        agent.env = _FailingEnv()
+        assert agent._publish_final_work() is False
+
+    def test_publish_reports_success_and_targets_the_agent_branch(self, pair):
+        alice_comm, _ = pair
+        agent = _agent("agent1", alice_comm)
+        assert agent._publish_final_work() is True
+        cmd = agent.env.commands[-1]["command"]
+        assert "HEAD:refs/heads/agent1" in cmd
+        assert "worktree add" in cmd and "patch.txt" in cmd
+        assert f"{GIT_REMOTE}/main" in cmd, "must branch from the pristine base, not HEAD"


### PR DESCRIPTION
A coop pair has exactly two channels for coordinating. **Both reported success while conveying nothing.**

Found while analysing why Qwen3.5-9B scores 0/9 pairs on `flash_10` — the agents were coordinating, and the harness was throwing it away.

## 1. Messages to a finished peer vanish, and the sender is told they succeeded

When an agent submits and exits, its peer keeps sending into a mailbox nobody will read again. `send()` queued to Redis and returned success unconditionally — no liveness check.

Measured over 8 `flash_10` pairs: **16 sent, 11 delivered (31% lost)**.

| pair | sent | delivered |
|---|---|---|
| `pallets_click/2800/f1_f7` | 3 | **0** |
| `openai_tiktoken/0/f6_f8` | 4 | 3 |
| `pillow/290/f4_f5` | 6 | 6 |
| `go_chi/26/f1_f2` | 2 | 1 |

In the click pair all three were sent **35s after the peer's final turn**. The sender got `Message sent to agent2` (rc 0) each time, then wrote in its own summary:

> "Coordination with agent2 is **ongoing** via send_message — edits target different files, no expected conflicts."

…and submitted a patch that merge-conflicted. A merge conflict is an automatic double failure, so that pair scored 0 on both features.

## 2. `--wait` was documented but never implemented

`_handle_send_message` guarded on `hasattr(self.comm, "send_and_wait")`; `MessagingConnector` had no such method. So `send_message --wait` — advertised in the prompt as "block until your colleague responds" — silently degraded to fire-and-forget.

## 3. `team/<peer>` never contained the peer's work

`GitConnector.setup()` pushes the base commit once; nothing updates the branch afterwards. The prompt presents that remote as the way to see a colleague's code.

**Zero pushes across all 19 agent runs.** One agent ran 24 `git fetch` / `git diff team/agent2` commands, saw the untouched baseline every time, and asked "have you submitted your branch yet?" — to a peer that had already finished.

## Fixes

- `send()` returns `False` for a departed peer; the agent gets a **non-zero** result naming the cause and the recovery path.
- `send_and_wait()` implemented — ends on reply **or peer exit**, instead of burning the full 60s.
- Each agent publishes its **submitted patch** to `team/<agent_id>` on exit. `patch.txt` is the evaluated artifact and may be a subset of the working tree, so publishing the tree would show the peer something other than what gets merged.
- Peers are told once when a colleague exits, with the branch to reconcile against.
- Prompt states what `team/<peer>` holds and when, that `--wait` can return early, and that a colleague may exit first.

### Publication is careful about two things

**It must not lie.** Publication is best-effort, so the exit marker records whether the patch *actually landed* (`mark_exited(published=...)`), and peers are pointed at the branch only when it really holds the submission. Otherwise this would reintroduce exactly the bug being fixed.

**It must not corrupt the agent's state.** Built in a detached worktree from the **pristine base** (`team/main`), not from `HEAD` — if the agent had already committed its work, applying `patch.txt` on top of `HEAD` would double-apply it. The agent's branch, index and working tree are untouched, and the adapter still reads `patch.txt` afterwards.

## Testing

- `tests/`: **392 passed**, 63 skipped. The 2 `test_team_wiring.py` failures are a missing optional `openhands` module and reproduce on clean `main`.
- 9 new tests in `test_messaging.py` covering: delivery to a live vs departed peer, the `published` flag distinguishing a failed publish, `--wait` returning in <5s on a departed peer (vs 60s), abandoning the wait when the peer exits mid-wait, and stale exit markers being cleared on a fresh run.
- The publish script was verified against a real git fixture including the "agent already committed" case: published branch is base+patch applied **exactly once**, agent's `HEAD` and working tree unchanged, no worktrees leaked, and a missing `patch.txt` exits non-zero rather than reporting a successful publication.

Bumps to 0.0.22; adds the missing 0.0.20 / 0.0.21 changelog entries.